### PR TITLE
feat(select): let `condition` be undefined

### DIFF
--- a/src/array/select.ts
+++ b/src/array/select.ts
@@ -8,12 +8,13 @@
 export const select = <T, K>(
   array: readonly T[],
   mapper: (item: T, index: number) => K,
-  condition: (item: T, index: number) => boolean
+  condition?: (item: T, index: number) => boolean
 ) => {
   if (!array) return []
+  let mapped: K
   return array.reduce((acc, item, index) => {
-    if (!condition(item, index)) return acc
-    acc.push(mapper(item, index))
+    if (condition) condition(item, index) && acc.push(mapper(item, index))
+    else (mapped = mapper(item, index)) != null && acc.push(mapped)
     return acc
   }, [] as K[])
 }

--- a/src/array/tests/select.test.ts
+++ b/src/array/tests/select.test.ts
@@ -52,4 +52,9 @@ describe('select function', () => {
     )
     expect(result).toEqual(['c2', 'd3'])
   })
+  test('works without a condition callback', () => {
+    const list = [{ a: 1 }, { b: 2 }, { a: 3 }, { a: null }, { a: undefined }]
+    const result = _.select(list, obj => obj.a)
+    expect(result).toEqual([1, 3])
+  })
 })


### PR DESCRIPTION
## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->

If the `condition` parameter is undefined, the `mapper` result is checked with `!= null` instead, so `null` and `undefined` results are omitted from the new array.

```ts
const result = select(
  [{ a: 1 }, { a: 2 }, { b: 1 }],
  (obj) => obj.a,
)

expect(result).toEqual([1, 2])
```

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->

Resolves https://github.com/sodiray/radash/issues/269