### PR TITLE
feat(unique): let `toKey` return any kind of value

### DIFF
--- a/src/array/tests/unique.test.ts
+++ b/src/array/tests/unique.test.ts
@@ -23,4 +23,24 @@ describe('unique function', () => {
     expect(c.id).toBe('c')
     expect(c.word).toBe('yolo')
   })
+  test('correctly handles non string, number or symbol values', () => {
+    const list: any[] = [
+      null,
+      null,
+      true,
+      true,
+      'true',
+      false,
+      { id: 'a', word: 'hello' },
+      { id: 'a', word: 'hello' }
+    ]
+    const result = _.unique(list, val => (val && val.id) ?? val)
+    expect(result).toEqual([
+      null,
+      true,
+      'true',
+      false,
+      { id: 'a', word: 'hello' }
+    ])
+  })
 })

--- a/src/array/unique.ts
+++ b/src/array/unique.ts
@@ -7,13 +7,16 @@ export const unique = <T, K = T>(
   array: readonly T[],
   toKey?: (item: T) => K
 ): T[] => {
-  const known = new Set<T | K>()
-  return array.reduce((acc, item) => {
-    const key = toKey ? toKey(item) : item
-    if (!known.has(key)) {
-      known.add(key)
-      acc.push(item)
-    }
-    return acc
-  }, [] as T[])
+  if (toKey) {
+    const keys = new Set<K>()
+    return array.reduce((acc, item) => {
+      const key = toKey(item)
+      if (!keys.has(key)) {
+        keys.add(key)
+        acc.push(item)
+      }
+      return acc
+    }, [] as T[])
+  }
+  return [...new Set(array)]
 }

--- a/src/array/unique.ts
+++ b/src/array/unique.ts
@@ -3,15 +3,17 @@
  * Accepts an optional identity function to convert each item in the
  * list to a comparable identity value
  */
-export const unique = <T, K extends string | number | symbol>(
+export const unique = <T, K = T>(
   array: readonly T[],
   toKey?: (item: T) => K
 ): T[] => {
-  const valueMap = array.reduce((acc, item) => {
-    const key = toKey ? toKey(item) : (item as any as string | number | symbol)
-    if (acc[key]) return acc
-    acc[key] = item
+  const known = new Set<T | K>()
+  return array.reduce((acc, item) => {
+    const key = toKey ? toKey(item) : item
+    if (!known.has(key)) {
+      known.add(key)
+      acc.push(item)
+    }
     return acc
-  }, {} as Record<string | number | symbol, T>)
-  return Object.values(valueMap)
+  }, [] as T[])
 }


### PR DESCRIPTION
## Description

Allow `unique`'s `toKey` parameter to return any value, instead of only values that can be identified through a key or those that can be used as keys themselves.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

Resolves https://github.com/sodiray/radash/issues/342