### PR TITLE
fix(shake): stop using `Omit` on return type and give `filter` parameter a safer type

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -15,19 +15,17 @@ type UppercasedKeys<T extends Record<string, any>> = {
  * object. Optional second argument shakes out values
  * by custom evaluation.
  */
-export const shake = <RemovedKeys extends string, T>(
+export const shake = <T extends object>(
   obj: T,
-  filter: (value: any) => boolean = x => x === undefined
-): Omit<T, RemovedKeys> => {
+  filter = (value: T[keyof T]): boolean => value === undefined
+): T => {
   if (!obj) return {} as T
   const keys = Object.keys(obj) as (keyof T)[]
   return keys.reduce((acc, key) => {
-    if (filter(obj[key])) {
-      return acc
-    } else {
+    if (!filter(obj[key])) {
       acc[key] = obj[key]
-      return acc
     }
+    return acc
   }, {} as T)
 }
 

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -36,7 +36,7 @@ describe('object module', () => {
       })
     })
     test('handles undefined input', () => {
-      const result = _.shake(undefined)
+      const result = _.shake(undefined!)
       expect(result).toEqual({})
     })
   })


### PR DESCRIPTION
## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->

The `shake` function cannot make any guarantees at the type-level about the returned object, so the return type should just be `T`.

Also, its `filter` callback now has a correctly typed `value` parameter.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->

Resolves https://github.com/sodiray/radash/pull/404

Thanks to @AliubYiero