### PR TITLE
fix(series): allow `items` param to be a readonly array

### DIFF
--- a/src/series.ts
+++ b/src/series.ts
@@ -5,7 +5,7 @@ import { list } from './array'
  * that should be treated with order.
  */
 export const series = <T>(
-  items: T[],
+  items: readonly T[],
   toKey: (item: T) => string | symbol = item => `${item}`
 ) => {
   const { indexesByKey, itemsByIndex } = items.reduce(

--- a/src/tests/series.test.ts
+++ b/src/tests/series.test.ts
@@ -2,14 +2,13 @@ import { expect } from 'vitest'
 import * as _ from '..'
 
 describe('series module', () => {
-  type Weekday = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday'
-  const sut = _.series<Weekday>([
+  const sut = _.series([
     'monday',
     'tuesday',
     'wednesday',
     'thursday',
     'friday'
-  ])
+  ] as const)
 
   describe('min function', () => {
     test('correctly returns min', () => {


### PR DESCRIPTION
## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->

Resolves https://github.com/sodiray/radash/pull/272

Thanks to @JacobWeisenburger