### PR TITLE
fix(set): avoid false positive of array index in path

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -249,7 +249,8 @@ export const set = <T extends object, K>(
   const _set = (node: any) => {
     if (segments.length > 1) {
       const key = segments.shift() as string
-      const nextIsNum = toInt(segments[0], null) === null ? false : true
+      const numCast = toInt(segments[0], null)
+      const nextIsNum = numCast !== null && numCast.toString().length === segments[0].length
       node[key] = node[key] === undefined ? (nextIsNum ? [] : {}) : node[key]
       _set(node[key])
     } else {

--- a/src/object.ts
+++ b/src/object.ts
@@ -249,9 +249,13 @@ export const set = <T extends object, K>(
   const _set = (node: any) => {
     if (segments.length > 1) {
       const key = segments.shift() as string
-      const numCast = toInt(segments[0], null)
-      const nextIsNum = numCast !== null && numCast.toString().length === segments[0].length
-      node[key] = node[key] === undefined ? (nextIsNum ? [] : {}) : node[key]
+      node[key] =
+        node[key] === undefined
+          ? Number.isNaN(Number(segments[0]))
+            ? {}
+            : []
+          : node[key]
+
       _set(node[key])
     } else {
       node[segments[0]] = value

--- a/src/tests/object.test.ts
+++ b/src/tests/object.test.ts
@@ -496,14 +496,28 @@ describe('object module', () => {
       expect(_.set({}, 'cards.0.value', 2)).toEqual({
         cards: [{ value: 2 }]
       })
+      expect(_.set({}, 'cards.2.value', 2)).toEqual({
+        cards: [, , { value: 2 }]
+      })
       expect(_.set({}, 'cards.0.0.value', 2)).toEqual({
         cards: [[{ value: 2 }]]
+      })
+      expect(_.set({}, 'cards.2.2.value', 2)).toEqual({
+        cards: [, , [, , { value: 2 }]]
       })
       expect(_.set({}, 'cards.[0].[0].value', 2)).toEqual({
         cards: [[{ value: 2 }]]
       })
       expect(_.set({}, 'cards.[1].[1].value', 2)).toEqual({
         cards: [, [, { value: 2 }]]
+      })
+    })
+    test('sets keys starting with numbers correctly', () => {
+      expect(_.set({}, 'cards.0value', 2)).toEqual({
+        cards: { '0value': 2 }
+      })
+      expect(_.set({}, 'cards.1234value', 2)).toEqual({
+        cards: { '1234value': 2 }
       })
     })
   })


### PR DESCRIPTION
## Description

Avoid cases in `set(…)` where a key starts with an integer (but is not only an integer) being inferred as an array index.

## Checklist

- [x] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [x] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->

Resolves https://github.com/sodiray/radash/pull/383 and https://github.com/sodiray/radash/issues/357

Thanks @UnKnoWn-Consortium