### PR TITLE
fix: avoid `isObject` for internal use

### DIFF
--- a/docs/typed/is-object.mdx
+++ b/docs/typed/is-object.mdx
@@ -16,3 +16,5 @@ isObject(['hello']) // => false
 isObject(null) // => false
 isObject({ say: 'hello' }) // => true
 ```
+
+**Beware:** This function returns `false` for objects created with `Object.create(null)`.

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -10,7 +10,10 @@ export const assign = <X extends Record<string | symbol | number, any>>(
   override: X
 ): X => {
   if (!initial || !override) return initial ?? override ?? {}
-  const merged = { ...initial }
+  const proto = Object.getPrototypeOf(initial)
+  const merged = proto
+    ? { ...initial }
+    : Object.assign(Object.create(proto), initial)
   for (const key in override) {
     if (Object.prototype.hasOwnProperty.call(override, key)) {
       merged[key] = isPlainObject(initial[key])

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -1,4 +1,4 @@
-import { isObject } from 'radashi'
+import { isPlainObject } from 'radashi'
 
 /**
  * Merges two objects together recursivly into a new object applying
@@ -13,7 +13,7 @@ export const assign = <X extends Record<string | symbol | number, any>>(
   const merged = { ...initial }
   for (const key in override) {
     if (Object.prototype.hasOwnProperty.call(override, key)) {
-      merged[key] = isObject(initial[key])
+      merged[key] = isPlainObject(initial[key])
         ? assign(initial[key], override[key])
         : override[key]
     }

--- a/src/object/keys.ts
+++ b/src/object/keys.ts
@@ -1,5 +1,4 @@
-import { isArray } from 'radashi'
-import { isObject } from 'radashi'
+import { isArray, isPlainObject } from 'radashi'
 
 /**
  * Get a string list of all key names that exist in an object (deep).
@@ -11,7 +10,7 @@ import { isObject } from 'radashi'
 export const keys = <TValue extends object>(value: TValue): string[] => {
   if (!value) return []
   const getKeys = (nested: any, paths: string[]): string[] => {
-    if (isObject(nested)) {
+    if (isPlainObject(nested)) {
       return Object.entries(nested).flatMap(([k, v]) =>
         getKeys(v, [...paths, k])
       )

--- a/src/object/tests/assign.test.ts
+++ b/src/object/tests/assign.test.ts
@@ -49,4 +49,13 @@ describe('assign function', () => {
     const result = _.assign({}, { b: 'y' })
     expect(result).toEqual({ b: 'y' })
   })
+  test('works with Object.create(null)', () => {
+    const object = { a: Object.create(null) }
+    object.a.b = 1
+
+    const result = _.assign(object, { a: { c: 2 } })
+
+    expect(result).toEqual({ a: { b: 1, c: 2 } })
+    expect(Object.getPrototypeOf(result.a)).toBe(null)
+  })
 })

--- a/src/object/tests/keys.test.ts
+++ b/src/object/tests/keys.test.ts
@@ -30,4 +30,12 @@ describe('keys function', () => {
       'enemies.0.power'
     ])
   })
+  test('works with Object.create(null)', () => {
+    const object = Object.create(null)
+    object.a = 1
+    object.b = [2]
+    object.c = { d: 3 }
+    const result = _.keys(object)
+    expect(result).toEqual(['a', 'b.0', 'c.d'])
+  })
 })


### PR DESCRIPTION
## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->

Using `isObject` internally is hostile to any use case in need of `Object.create(null)`, so we'll use `isPlainObject` instead.

Affected functions include:
- `assign`
- `crush`
- `keys`

### What does this mean?

When an object created with `Object.create(null)` is nested in the argument to `assign`, `crush`, or `keys`, it will be treated as if it was created with `{}`. In the case of `assign`, any time such an object is assigned to, the resulting clone of the object will have a null prototype as expected.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->
Resolves https://github.com/sodiray/radash/issues/409
