### PR TITLE
fix(crush): support dot in property name

### DIFF
--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -21,19 +21,20 @@ type Primitive =
 	| undefined
 	| null;
 
+const crushToPvArray: (
+	obj: object,
+	path: string,
+) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
+	Object.entries(obj).flatMap(([key, value]) =>
+		isPrimitive(value) || isDate(value)
+			? { p: path === "" ? key : `${path}.${key}`, v: value }
+			: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
+	);
+
 export function crush<TValue extends object>(
 	value: TValue,
 ): Record<string, Primitive> | Record<string, never> {
 	if (!value) return {};
-	const crushToPvArray: (
-		obj: object,
-		path: string,
-	) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-		Object.entries(obj).flatMap(([key, value]) =>
-			isPrimitive(value) || isDate(value)
-				? { p: path === "" ? key : `${path}.${key}`, v: value }
-				: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
-		);
 
 	const result = objectify(
 		crushToPvArray(value, ""),

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -13,7 +13,7 @@ import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
  */
 export function crush<T extends object>(value: T): Crush<T> {
   if (!value) {
-    return {}
+    return {} as Crush<T>
   }
   return (function crushReducer(
     crushed: Crush<T>,

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,4 @@
-import { isDate, isPrimitive, objectify } from "radashi";
+import { isDate, isPrimitive, objectify } from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -12,34 +12,36 @@ import { isDate, isPrimitive, objectify } from "radashi";
  * ```
  */
 type Primitive =
-	| number
-	| string
-	| boolean
-	| Date
-	| symbol
-	| bigint
-	| undefined
-	| null;
+  | number
+  | string
+  | boolean
+  | Date
+  | symbol
+  | bigint
+  | undefined
+  | null
 
 const crushToPvArray: (
-	obj: object,
-	path: string,
+  obj: object,
+  path: string,
 ) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-	Object.entries(obj).flatMap(([key, value]) =>
-		isPrimitive(value) || isDate(value)
-			? { p: path === "" ? key : `${path}.${key}`, v: value }
-			: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
-	);
+  Object.entries(obj).flatMap(([key, value]) =>
+    isPrimitive(value) || isDate(value)
+      ? { p: path === '' ? key : `${path}.${key}`, v: value }
+      : crushToPvArray(value, path === '' ? key : `${path}.${key}`),
+  )
 
 export function crush<TValue extends object>(
-	value: TValue,
+  value: TValue,
 ): Record<string, Primitive> | Record<string, never> {
-	if (!value) return {};
+  if (!value) {
+    return {}
+  }
 
-	const result = objectify(
-		crushToPvArray(value, ""),
-		(o) => o.p,
-		(o) => o.v,
-	);
-	return result;
+  const result = objectify(
+    crushToPvArray(value, ''),
+    o => o.p,
+    o => o.v,
+  )
+  return result
 }

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,4 @@
-import { isDate, isPrimitive, objectify } from 'radashi'
+import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -11,37 +11,54 @@ import { isDate, isPrimitive, objectify } from 'radashi'
  * // { name: 'ra', 'children.0.name': 'hathor' }
  * ```
  */
-type Primitive =
-  | number
-  | string
-  | boolean
-  | Date
-  | symbol
-  | bigint
-  | undefined
-  | null
-
-const crushToPvArray: (
-  obj: object,
-  path: string,
-) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-  Object.entries(obj).flatMap(([key, value]) =>
-    isPrimitive(value) || isDate(value)
-      ? { p: path === '' ? key : `${path}.${key}`, v: value }
-      : crushToPvArray(value, path === '' ? key : `${path}.${key}`),
-  )
-
-export function crush<TValue extends object>(
-  value: TValue,
-): Record<string, Primitive> | Record<string, never> {
+export function crush<T extends object>(value: T): Crush<T> {
   if (!value) {
     return {}
   }
-
-  const result = objectify(
-    crushToPvArray(value, ''),
-    o => o.p,
-    o => o.v,
-  )
-  return result
+  return (function crushReducer(
+    crushed: Crush<T>,
+    value: unknown,
+    path: string,
+  ) {
+    if (isObject(value) || isArray(value)) {
+      for (const [prop, propValue] of Object.entries(value)) {
+        crushReducer(crushed, propValue, path ? `${path}.${prop}` : prop)
+      }
+    } else {
+      crushed[path as keyof Crush<T>] = value as Crush<T>[keyof Crush<T>]
+    }
+    return crushed
+  })({} as Crush<T>, value, '')
 }
+
+/**
+ * The return type of the `crush` function.
+ *
+ * This type is limited by TypeScript's development. There's no
+ * reliable way to detect if an object will pass `isObject` or not, so
+ * we cannot infer the property types of nested objects that have been
+ * crushed.
+ *
+ * @see https://radashi-org.github.io/reference/object/crush
+ */
+export type Crush<T> = T extends readonly (infer U)[]
+  ? Record<string, U extends object ? unknown : U>
+  : Simplify<
+      Intersect<
+        keyof T extends infer Prop
+          ? Prop extends keyof T
+            ? T[Prop] extends infer Value
+              ?
+                  | ([Extract<Value, object>] extends [never]
+                      ? never
+                      : Record<string, unknown>)
+                  | ([Exclude<Value, object>] extends [never]
+                      ? never
+                      : [Extract<Value, object>] extends [never]
+                        ? { [P in Prop]: Value }
+                        : Record<string, unknown>)
+              : never
+            : never
+          : never
+      >
+    >

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,3 +108,19 @@ export type ComparableProperty<T> = CompatibleProperty<T, Comparable>
  * value, and 0 to keep the order of the values.
  */
 export type Comparator<T> = (left: T, right: T) => number
+
+/** Convert a union to an intersection */
+export type Intersect<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
+
+/**
+ * Useful to flatten the type output to improve type hints shown in
+ * editors. And also to transform an interface into a type to aide
+ * with assignability.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/15300
+ */
+export type Simplify<T> = {} & { [P in keyof T]: T[P] }

--- a/tests/object/crush.test-d.ts
+++ b/tests/object/crush.test-d.ts
@@ -1,0 +1,53 @@
+import * as _ from 'radashi'
+
+describe('crush', () => {
+  test('direct properties are preserved in the result type', () => {
+    const obj = _.crush({ a: 1, b: '2', c: true })
+    expectTypeOf(obj).toEqualTypeOf<{ a: number; b: string; c: boolean }>()
+  })
+  test('nested objects add Record to result type', () => {
+    const obj = _.crush({ a: { b: 1 } })
+    expectTypeOf(obj).toEqualTypeOf<Record<string, unknown>>()
+
+    const obj2 = _.crush({ a: 1, b: { c: 2 } })
+    expectTypeOf(obj2).toEqualTypeOf<{ a: number; [key: string]: unknown }>()
+    expectTypeOf(obj2.a).toEqualTypeOf<number>()
+    expectTypeOf(obj2['b.c']).toEqualTypeOf<unknown>()
+  })
+  test('optional property', () => {
+    const obj = _.crush({} as { a?: number })
+    // FIXME: Try to preserve optionality.
+    expectTypeOf(obj).toEqualTypeOf<{ a: number | undefined }>()
+  })
+  test('crushed Record type', () => {
+    const obj = _.crush({} as Record<number, number>)
+    expectTypeOf(obj).toEqualTypeOf<Record<number, number>>()
+
+    const obj2 = _.crush({} as Record<string, string>)
+    expectTypeOf(obj2).toEqualTypeOf<Record<string, string>>()
+
+    const obj3 = _.crush({} as Record<number, number | object>)
+    expectTypeOf(obj3).toEqualTypeOf<Record<string, unknown>>()
+
+    const obj4 = _.crush({} as Record<string, string | unknown[]>)
+    expectTypeOf(obj4).toEqualTypeOf<Record<string, unknown>>()
+  })
+  test('crushed array', () => {
+    // We cannot assume the keys from "number[]" input value, but we
+    // *can* assume the value type. Note that the value type doesn't
+    // contain "undefined" (which matches array behavior).
+    const obj = _.crush([1, 2, 3])
+    expectTypeOf(obj).toEqualTypeOf<Record<string, number>>()
+
+    const obj2 = _.crush([1, { b: 2 }])
+    expectTypeOf(obj2).toEqualTypeOf<Record<string, unknown>>()
+    expectTypeOf(obj2[0]).toEqualTypeOf<unknown>()
+  })
+  test('union type with object and primitive', () => {
+    // Since "a" may be an object, we cannot assume the result will
+    // have an "a" property. Therefore, the keys and values of the
+    // result are unknown.
+    const obj = _.crush({ a: {} as number | object })
+    expectTypeOf(obj).toEqualTypeOf<Record<string, unknown>>()
+  })
+})

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,4 +33,12 @@ describe('crush', () => {
       timestamp: now,
     })
   })
+  test('handles property names with dots', () => {
+    const obj = {
+      a: { 'b.c': 'value' }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c': 'value'
+    })
+  })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,12 +33,36 @@ describe('crush', () => {
       timestamp: now,
     })
   })
-  test('handles property names with dots', () => {
+  test('handles property names with dots 1', () => {
     const obj = {
       a: { 'b.c': 'value' }
     }
     expect(_.crush(obj)).toEqual({
       'a.b.c': 'value'
+    })
+  })
+  test('handles property names with dots 2', () => {
+    const obj = {
+      'a.b': { c: 'value' }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c': 'value'
+    })
+  })
+  test('handles property names with dots 3', () => {
+    const obj = {
+      'a.b': { 'c.d': 123.4 }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c.d': 123.4
+    })
+  })
+  test('handles arrays', () => {
+    const obj = ['value', 123.4, true]
+    expect(_.crush(obj)).toEqual({
+      '0': 'value',
+      '1': 123.4,
+      '2': true
     })
   })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,36 +33,67 @@ describe('crush', () => {
       timestamp: now,
     })
   })
-  test('handles property names with dots 1', () => {
-    const obj = {
-      a: { 'b.c': 'value' },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value',
-    })
-  })
-  test('handles property names with dots 2', () => {
-    const obj = {
-      'a.b': { c: 'value' },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value',
-    })
-  })
-  test('handles property names with dots 3', () => {
-    const obj = {
-      'a.b': { 'c.d': 123.4 },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c.d': 123.4,
-    })
-  })
   test('handles arrays', () => {
     const obj = ['value', 123.4, true]
     expect(_.crush(obj)).toEqual({
       '0': 'value',
       '1': 123.4,
       '2': true,
+    })
+  })
+  describe('property names containing period', () => {
+    test('inside the root object', () => {
+      const obj = {
+        'a.b': { c: 'value' },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c': 'value',
+      })
+    })
+    test('inside a nested object', () => {
+      const obj = {
+        a: { 'b.c': 'value' },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c': 'value',
+      })
+    })
+    test('inside both root and nested object', () => {
+      const obj = {
+        'a.b': { 'c.d': 123.4 },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c.d': 123.4,
+      })
+    })
+    test('crush array containing object with nested property', () => {
+      const arr = [{ 'c.d': { 'e.f': 'g' } }]
+      const obj = {
+        'a.b': arr,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.0.c.d.e.f': 'g',
+      })
+    })
+    test('do not crush Date objects', () => {
+      const date = new Date()
+      const obj = {
+        'a.b': date,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b': date,
+      })
+    })
+    test('do not crush Map objects', () => {
+      const map = new Map()
+      map.set('a', 'b')
+      map.set('c', 'd')
+      const obj = {
+        'a.b': map,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b': map,
+      })
     })
   })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -35,26 +35,26 @@ describe('crush', () => {
   })
   test('handles property names with dots 1', () => {
     const obj = {
-      a: { 'b.c': 'value' }
+      a: { 'b.c': 'value' },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value'
+      'a.b.c': 'value',
     })
   })
   test('handles property names with dots 2', () => {
     const obj = {
-      'a.b': { c: 'value' }
+      'a.b': { c: 'value' },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value'
+      'a.b.c': 'value',
     })
   })
   test('handles property names with dots 3', () => {
     const obj = {
-      'a.b': { 'c.d': 123.4 }
+      'a.b': { 'c.d': 123.4 },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c.d': 123.4
+      'a.b.c.d': 123.4,
     })
   })
   test('handles arrays', () => {
@@ -62,7 +62,7 @@ describe('crush', () => {
     expect(_.crush(obj)).toEqual({
       '0': 'value',
       '1': 123.4,
-      '2': true
+      '2': true,
     })
   })
 })


### PR DESCRIPTION
> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->
Currently, the `crush` function combines the `objectify` and `keys` functions to achieve its behavior.

The cause of the issue is with `keys` creating no discernible difference between a property with a dot in it (i.e. `{"a.b":1} => "a.b"`) and a property path of multiple property names (i.e. `{a:{b:1}} => "a.b"`).

As of now, this PR only adds a test case to verify the bug report by @stefaanMLB.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [x] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->
Resolves https://github.com/sodiray/radash/issues/365


## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/object/crush.ts` | 295[^1337] | -396 (-58%) |

[^1337]: Function size includes the `import` dependencies of the function.

