### PR TITLE
chore: upgrade typescript and use --isolatedDeclarations

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -151,6 +151,6 @@ jobs:
 
       - name: Publish to JSR
         run: |
-          deno run -A jsr:@david/publish-on-tag@0.1.4 --allow-slow-types --allow-dirty
+          deno run -A jsr:@david/publish-on-tag@0.1.4 --allow-dirty
         env:
           GITHUB_REF: refs/tags/v${{ needs.prepare-version.outputs.version }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
     "source.organizeImports",
     "source.formatDocument"
   ],
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.preferences.autoImportFileExcludePatterns": [
     "**/node_modules/**",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vitest/coverage-v8": "^1.6.0",
     "prettier": "^2.7.1",
     "tsup": "^8.1.0",
-    "typescript": "^4.8.4",
+    "typescript": "^5.5.2",
     "vitest": "^1.6.0"
   },
   "packageManager": "pnpm@9.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         version: 2.8.8
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(postcss@8.4.38)(typescript@4.9.5)
+        version: 8.1.0(postcss@8.4.38)(typescript@5.5.2)
       typescript:
-        specifier: ^4.8.4
-        version: 4.9.5
+        specifier: ^5.5.2
+        version: 5.5.2
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.8)
@@ -1066,9 +1066,9 @@ packages:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.5.3:
@@ -2079,7 +2079,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.1.0(postcss@8.4.38)(typescript@4.9.5):
+  tsup@8.1.0(postcss@8.4.38)(typescript@5.5.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -2097,14 +2097,14 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.4.38
-      typescript: 4.9.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
 
   type-detect@4.0.8: {}
 
-  typescript@4.9.5: {}
+  typescript@5.5.2: {}
 
   ufo@1.5.3: {}
 

--- a/src/array/alphabetical.ts
+++ b/src/array/alphabetical.ts
@@ -6,7 +6,7 @@ export function alphabetical<T>(
   array: readonly T[],
   getter: (item: T) => string,
   dir: 'asc' | 'desc' = 'asc',
-) {
+): T[] {
   if (!array) {
     return []
   }

--- a/src/array/boil.ts
+++ b/src/array/boil.ts
@@ -7,7 +7,10 @@
  * boil([1, 2, 3, 0], (a, b) => a > b ? a : b) // 3
  * ```
  */
-export function boil<T>(array: readonly T[], compareFunc: (a: T, b: T) => T) {
+export function boil<T>(
+  array: readonly T[],
+  compareFunc: (a: T, b: T) => T,
+): T | null {
   if (!array || (array.length ?? 0) === 0) {
     return null
   }

--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -9,9 +9,10 @@
  * // 0
  * ```
  */
-export function first<T>(
-  array: readonly T[],
-  defaultValue: T | null | undefined = undefined,
-) {
+export function first<T>(array: readonly T[]): T | undefined
+
+export function first<T, U>(array: readonly T[], defaultValue: U): T | U
+
+export function first(array: readonly unknown[], defaultValue?: unknown) {
   return array?.length > 0 ? array[0] : defaultValue
 }

--- a/src/array/iterate.ts
+++ b/src/array/iterate.ts
@@ -14,7 +14,7 @@ export function iterate<T>(
   count: number,
   func: (currentValue: T, iteration: number) => T,
   initValue: T,
-) {
+): T {
   let value = initValue
   for (let i = 1; i <= count; i++) {
     value = func(value, i)

--- a/src/array/last.ts
+++ b/src/array/last.ts
@@ -9,9 +9,10 @@
  * // 0
  * ```
  */
-export function last<T>(
-  array: readonly T[],
-  defaultValue: T | null | undefined = undefined,
-) {
+export function last<T>(array: readonly T[]): T | undefined
+
+export function last<T, U>(array: readonly T[], defaultValue: U): T | U
+
+export function last(array: readonly unknown[], defaultValue?: unknown) {
   return array?.length > 0 ? array[array.length - 1] : defaultValue
 }

--- a/src/array/merge.ts
+++ b/src/array/merge.ts
@@ -16,18 +16,18 @@ export function merge<T>(
   root: readonly T[],
   others: readonly T[],
   matcher: (item: T) => any,
-) {
+): T[] {
   if (!others && !root) {
     return []
   }
   if (!others) {
-    return root
+    return [...root]
   }
   if (!root) {
     return []
   }
   if (!matcher) {
-    return root
+    return [...root]
   }
   return root.reduce((acc, r) => {
     const matched = others.find(o => matcher(r) === matcher(o))

--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -1,6 +1,11 @@
 /**
  * Replace an element in an array with a new item without modifying
  * the array and return the new value
+ *
+ * ```ts
+ * replace([1, 2, 3], 4, (n) => n === 2)
+ * // [1, 4, 3]
+ * ```
  */
 export function replace<T>(
   list: readonly T[],

--- a/src/array/replaceOrAppend.ts
+++ b/src/array/replaceOrAppend.ts
@@ -15,7 +15,7 @@ export function replaceOrAppend<T>(
   list: readonly T[],
   newItem: T,
   match: (a: T, idx: number) => boolean,
-) {
+): T[] {
   if (!list && !newItem) {
     return []
   }

--- a/src/array/select.ts
+++ b/src/array/select.ts
@@ -11,15 +11,15 @@
  * // => [9, 16]
  * ```
  */
-export function select<T, K>(
+export function select<T, U>(
   array: readonly T[],
-  mapper: (item: T, index: number) => K,
+  mapper: (item: T, index: number) => U,
   condition?: (item: T, index: number) => boolean,
-) {
+): U[] {
   if (!array) {
     return []
   }
-  let mapped: K
+  let mapped: U
   return array.reduce((acc, item, index) => {
     if (condition) {
       condition(item, index) && acc.push(mapper(item, index))
@@ -27,5 +27,5 @@ export function select<T, K>(
       acc.push(mapped)
     }
     return acc
-  }, [] as K[])
+  }, [] as U[])
 }

--- a/src/array/sort.ts
+++ b/src/array/sort.ts
@@ -17,7 +17,7 @@ export function sort<T>(
   array: readonly T[],
   getter: (item: T) => number,
   desc = false,
-) {
+): T[] {
   if (!array) {
     return []
   }

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -29,7 +29,7 @@ export function toggle<T>(
   options?: {
     strategy?: 'prepend' | 'append'
   },
-) {
+): T[] {
   if (!list && !item) {
     return []
   }

--- a/src/async/tests/retry.test.ts
+++ b/src/async/tests/retry.test.ts
@@ -8,7 +8,7 @@ describe('_.retry', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
   test('returns result of given function', async () => {
-    const result = await _.retry(cast(null), async bail => {
+    const result = await _.retry(cast(null), async _bail => {
       return 'hello'
     })
     expect(result).toBe('hello')
@@ -21,7 +21,7 @@ describe('_.retry', () => {
   })
   test('retries on failure', async () => {
     let failedOnce = false
-    const result = await _.retry(cast(null), async bail => {
+    const result = await _.retry(cast(null), async _bail => {
       if (!failedOnce) {
         failedOnce = true
         throw 'Failing for test'

--- a/src/curry/callable.ts
+++ b/src/curry/callable.ts
@@ -24,6 +24,6 @@ export function callable<
       ;(target as any)[key] = value
       return true
     },
-    apply: (target, self, args) => fn(Object.assign({}, target))(...args),
+    apply: (target, _, args) => fn(Object.assign({}, target))(...args),
   }) as unknown as TObj & TFunc
 }

--- a/src/curry/debounce.ts
+++ b/src/curry/debounce.ts
@@ -29,7 +29,7 @@ export type DebounceFunction<TArgs extends any[]> = {
 export function debounce<TArgs extends any[]>(
   { delay }: { delay: number },
   func: (...args: TArgs) => any,
-) {
+): DebounceFunction<TArgs> {
   let timer: unknown = undefined
   let active = true
 

--- a/src/curry/partial.ts
+++ b/src/curry/partial.ts
@@ -30,7 +30,6 @@ type RemoveItemsInFront<
 export function partial<T extends any[], TA extends Partial<T>, R>(
   fn: (...args: T) => R,
   ...args: TA
-) {
-  return (...rest: RemoveItemsInFront<T, TA>) =>
-    fn(...([...args, ...rest] as T))
+): (...rest: RemoveItemsInFront<T, TA>) => R {
+  return (...rest) => fn(...([...args, ...rest] as T))
 }

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -16,7 +16,7 @@ export type ThrottledFunction<TArgs extends any[]> = {
 export function throttle<TArgs extends any[]>(
   { interval }: { interval: number },
   func: (...args: TArgs) => any,
-) {
+): ThrottledFunction<TArgs> {
   let ready = true
   let timer: unknown = undefined
 

--- a/src/object/listify.ts
+++ b/src/object/listify.ts
@@ -1,10 +1,10 @@
 /**
  * Convert an object to a list, mapping each entry into a list item
  */
-export function listify<TValue, TKey extends string | number | symbol, KResult>(
-  obj: Record<TKey, TValue>,
-  toItem: (key: TKey, value: TValue) => KResult,
-) {
+export function listify<Value, Key extends string | number | symbol, Item>(
+  obj: Record<Key, Value>,
+  toItem: (key: Key, value: Value) => Item,
+): Item[] {
   if (!obj) {
     return []
   }
@@ -13,7 +13,7 @@ export function listify<TValue, TKey extends string | number | symbol, KResult>(
     return []
   }
   return entries.reduce((acc, entry) => {
-    acc.push(toItem(entry[0] as TKey, entry[1] as TValue))
+    acc.push(toItem(entry[0] as Key, entry[1] as Value))
     return acc
-  }, [] as KResult[])
+  }, [] as Item[])
 }

--- a/src/series/series.ts
+++ b/src/series/series.ts
@@ -1,5 +1,15 @@
 import { list } from 'radashi'
 
+export interface Series<T> {
+  min: (a: T, b: T) => T
+  max: (a: T, b: T) => T
+  first: () => T
+  last: () => T
+  next: (current: T, defaultValue?: T) => T
+  previous: (current: T, defaultValue?: T) => T
+  spin: (current: T, num: number) => T
+}
+
 /**
  * Creates a series object around a list of values that should be
  * treated with order.
@@ -7,7 +17,7 @@ import { list } from 'radashi'
 export const series = <T>(
   items: readonly T[],
   toKey: (item: T) => string | symbol = item => `${item}`,
-) => {
+): Series<T> => {
   const { indexesByKey, itemsByIndex } = items.reduce(
     (acc, item, idx) => ({
       indexesByKey: {
@@ -24,78 +34,70 @@ export const series = <T>(
       itemsByIndex: {} as Record<number, T>,
     },
   )
-  /**
-   * Given two values in the series, returns the value that occurs
-   * earlier in the series.
-   */
-  const min = (a: T, b: T): T => {
-    return indexesByKey[toKey(a)] < indexesByKey[toKey(b)] ? a : b
-  }
-  /**
-   * Given two values in the series, returns the value that occurs
-   * later in the series.
-   */
-  const max = (a: T, b: T): T => {
-    return indexesByKey[toKey(a)] > indexesByKey[toKey(b)] ? a : b
-  }
+
   /**
    * Returns the first item from the series.
    */
-  const first = (): T => {
-    return itemsByIndex[0]
-  }
+  const first = (): T => itemsByIndex[0]
+
   /**
    * Returns the last item in the series.
    */
-  const last = (): T => {
-    return itemsByIndex[items.length - 1]
-  }
+  const last = (): T => itemsByIndex[items.length - 1]
+
   /**
    * Given an item in the series, returns the next item in the series
    * or `defaultValue` if the given value is the last item in the series.
    */
-  const next = (current: T, defaultValue?: T): T => {
-    return (
-      itemsByIndex[indexesByKey[toKey(current)] + 1] ?? defaultValue ?? first()
-    )
-  }
+  const next = (current: T, defaultValue?: T): T =>
+    itemsByIndex[indexesByKey[toKey(current)] + 1] ?? defaultValue ?? first()
+
   /**
    * Given an item in the series, returns the previous item in the
    * series or `defaultValue` if the given value is the first item in
    * the series.
    */
-  const previous = (current: T, defaultValue?: T): T => {
-    return (
-      itemsByIndex[indexesByKey[toKey(current)] - 1] ?? defaultValue ?? last()
-    )
-  }
-  /**
-   * A more dynamic method than `next` and `previous` that lets you move
-   * many times in either direction.
-   *
-   * ```ts
-   * series(weekdays).spin('wednesday', 3) // => 'monday'
-   * series(weekdays).spin('wednesday', -3) // => 'friday'
-   * ```
-   */
-  const spin = (current: T, num: number): T => {
-    if (num === 0) {
-      return current
-    }
-    const abs = Math.abs(num)
-    const rel = abs > items.length ? abs % items.length : abs
-    return list(0, rel - 1).reduce(
-      acc => (num > 0 ? next(acc) : previous(acc)),
-      current,
-    )
-  }
+  const previous = (current: T, defaultValue?: T): T =>
+    itemsByIndex[indexesByKey[toKey(current)] - 1] ?? defaultValue ?? last()
+
   return {
-    min,
-    max,
+    /**
+     * Given two values in the series, returns the value that occurs
+     * earlier in the series.
+     */
+    min(a, b) {
+      return indexesByKey[toKey(a)] < indexesByKey[toKey(b)] ? a : b
+    },
+    /**
+     * Given two values in the series, returns the value that occurs
+     * later in the series.
+     */
+    max(a, b) {
+      return indexesByKey[toKey(a)] > indexesByKey[toKey(b)] ? a : b
+    },
     first,
     last,
     next,
     previous,
-    spin,
+    /**
+     * A more dynamic method than `next` and `previous` that lets you move
+     * many times in either direction.
+     *
+     * ```ts
+     * series(weekdays).spin('wednesday', 3) // => 'monday'
+     * series(weekdays).spin('wednesday', -3) // => 'friday'
+     * ```
+     */
+    spin(current, num) {
+      if (num === 0) {
+        return current
+      }
+      const abs = Math.abs(num)
+      const rel = abs > items.length ? abs % items.length : abs
+      return list(0, rel - 1).reduce(
+        acc => (num > 0 ? next(acc) : previous(acc)),
+        current,
+      )
+    },
   }
 }

--- a/src/string/template.ts
+++ b/src/string/template.ts
@@ -13,8 +13,8 @@
 export function template(
   str: string,
   data: Record<string, any>,
-  regex = /\{\{(.+?)\}\}/g,
-) {
+  regex: RegExp = /\{\{(.+?)\}\}/g,
+): string {
   return Array.from(str.matchAll(regex)).reduce((acc, match) => {
     return acc.replace(match[0], data[match[1]])
   }, str)

--- a/src/string/trim.ts
+++ b/src/string/trim.ts
@@ -10,7 +10,10 @@
  * trim('222222__hello__1111111', '12_') // => 'hello'
  * ```
  */
-export function trim(str: string | null | undefined, charsToTrim = ' ') {
+export function trim(
+  str: string | null | undefined,
+  charsToTrim = ' ',
+): string {
   if (!str) {
     return ''
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "moduleResolution": "node",
-    "noEmit": true,
+    "outDir": "./dist/tmp",
+    "noEmitOnError": true,
+    "declaration": true,
+    "isolatedDeclarations": true,
     "target": "esnext",
     "lib": ["es2020"],
     "esModuleInterop": true,


### PR DESCRIPTION
> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Description

<!-- Please provide a detailed description of the changes and the intent behind them :) -->
The new `--isolatedDeclarations` flag in TypeScript enforces explicit types for module boundaries. I think this is a good fit for Radashi for two reasons:
1. Biome doesn't support this yet.
2. Currently, we use `--allow-slow-types` when publishing to JSR. This lets us avoid that.

Depends on https://github.com/radashi-org/radashi/pull/38

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

<!-- If the PR resolves an open issue tag it here. For example, `Resolves #34` -->
