### PR TITLE
perf(replace): avoid creating 2 intermediate arrays

### DIFF
--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -20,8 +20,7 @@ export function replace<T>(
   }
   const out = array.slice()
   for (let index = 0; index < array.length; index++) {
-    const item = array[index]
-    if (match(item, index)) {
+    if (match(array[index], index)) {
       out[index] = newItem
       break
     }

--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -22,7 +22,7 @@ export function replace<T>(
   for (let index = 0; index < array.length; index++) {
     const item = array[index]
     if (match(item, index)) {
-      out.splice(index, 1, newItem)
+      out[index] = newItem
       break
     }
   }

--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -18,15 +18,13 @@ export function replace<T>(
   if (newItem === undefined) {
     return [...array]
   }
-  for (let idx = 0; idx < array.length; idx++) {
-    const item = array[idx]
-    if (match(item, idx)) {
-      return [
-        ...array.slice(0, idx),
-        newItem,
-        ...array.slice(idx + 1, array.length),
-      ]
+  const out = array.slice()
+  for (let index = 0; index < array.length; index++) {
+    const item = array[index]
+    if (match(item, index)) {
+      out.splice(index, 1, newItem)
+      break
     }
   }
-  return [...array]
+  return out
 }


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Generally speaking, a `splice` should be better performance than allocating 2 arrays that will need to be garbage collected. Not sure how well the benchmarks detect GC-related perf issues, though.


*edit:* @Minhir realized we could use basic assignment instead of `splice`. 🎉 

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
