### PR TITLE
perf(cluster): avoid an array allocation

### DIFF
--- a/src/array/cluster.ts
+++ b/src/array/cluster.ts
@@ -7,8 +7,9 @@
  * ```
  */
 export function cluster<T>(array: readonly T[], size = 2): T[][] {
-  const clusterCount = Math.ceil(array.length / size)
-  return new Array(clusterCount).fill(null).map((_c: null, i: number) => {
-    return array.slice(i * size, i * size + size)
-  })
+  const clusters: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    clusters.push(array.slice(i, i + size))
+  }
+  return clusters
 }


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
The previous implementation used `new Array()`, filled it with nulls, then mapped it. That's two array allocations and two enumerations (the fill and the map), although the `fill` was probably very fast.

Either way, this PR avoids the `map` altogether and the code is just as tiny.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
