### PR TITLE
feat: add `unzip` function

### DIFF
--- a/benchmarks/array/unzip.bench.ts
+++ b/benchmarks/array/unzip.bench.ts
@@ -1,0 +1,11 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+describe('unzip', () => {
+  bench('with non-empty arrays', () => {
+    _.unzip([
+      ['a', 1, true],
+      ['b', 2, false],
+    ])
+  })
+})

--- a/docs/array/unzip.mdx
+++ b/docs/array/unzip.mdx
@@ -1,0 +1,22 @@
+---
+title: unzip
+description: Group array elements by their index position across the input arrays
+---
+
+## Basic usage
+
+Creates an array of ungrouped elements, where each resulting array contains all elements at a specific index from the input arrays. The first array contains all first elements, the second array contains all second elements, and so on.
+
+```ts
+import * as _ from 'radashi'
+
+_.unzip([
+  ['a', 1, true],
+  ['b', 2, false],
+])
+// => [
+//   ['a', 'b'],
+//   [1, 2],
+//   [true, false],
+// ]
+```

--- a/src/array/unzip.ts
+++ b/src/array/unzip.ts
@@ -1,0 +1,25 @@
+/**
+ * Creates an array of ungrouped elements, where each resulting array
+ * contains all elements at a specific index from the input arrays.
+ * The first array contains all first elements, the second array
+ * contains all second elements, and so on.
+ *
+ * ```ts
+ * unzip([['a', 1, true], ['b', 2, false]])
+ * // [['a', 'b'], [1, 2], [true, false]]
+ * ```
+ */
+export function unzip<T>(arrays: readonly (readonly T[])[]): T[][] {
+  if (!arrays || !arrays.length) {
+    return []
+  }
+  const out = new Array(
+    arrays.reduce((max, arr) => Math.max(max, arr.length), 0),
+  )
+  let index = 0
+  const get = (array: T[]) => array[index]
+  for (; index < out.length; index++) {
+    out[index] = Array.from(arrays as { length: number }, get)
+  }
+  return out
+}

--- a/src/array/zip.ts
+++ b/src/array/zip.ts
@@ -1,3 +1,5 @@
+import { unzip } from 'radashi'
+
 /**
  * Creates an array of grouped elements, the first of which contains
  * the first elements of the given arrays, the second of which
@@ -31,10 +33,5 @@ export function zip<T1, T2>(
   array2: readonly T2[],
 ): [T1, T2][]
 export function zip<T>(...arrays: (readonly T[])[]): T[][] {
-  if (!arrays || !arrays.length) {
-    return []
-  }
-  return new Array(Math.max(...arrays.map(({ length }) => length)))
-    .fill([])
-    .map((_, idx) => arrays.map(array => array[idx]))
+  return unzip(arrays)
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -27,6 +27,7 @@ export * from './array/sort.ts'
 export * from './array/sum.ts'
 export * from './array/toggle.ts'
 export * from './array/unique.ts'
+export * from './array/unzip.ts'
 export * from './array/zip.ts'
 export * from './array/zipToObject.ts'
 

--- a/tests/array/unzip.test.ts
+++ b/tests/array/unzip.test.ts
@@ -1,0 +1,15 @@
+import * as _ from 'radashi'
+
+describe('unzip', () => {
+  test('unzips an array correctly', () => {
+    const result = _.unzip([
+      ['a', 1, true],
+      ['b', 2, false],
+    ])
+    expect(result).toEqual([
+      ['a', 'b'],
+      [1, 2],
+      [true, false],
+    ])
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
The opposite of `zip`. In fact, `zip` uses `unzip` internally.

I also took this as an opportunity to improve the performance of `zip`, avoiding the `fill` and `map` calls, similar to what I did in #63.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
