### PR TITLE
fix: toInt and toFloat symbol input

### DIFF
--- a/src/number/toFloat.ts
+++ b/src/number/toFloat.ts
@@ -1,11 +1,23 @@
-export function toFloat<T extends number | null = number>(
+import { isSymbol } from 'radashi'
+
+export function toFloat(value: unknown): number
+
+export function toFloat(value: unknown, defaultValue: number): number
+
+export function toFloat<T>(
+  value: unknown,
+  defaultValue: T,
+): number | Exclude<T, undefined>
+
+export function toFloat<T>(
   value: any,
   defaultValue?: T,
-): number | T {
-  const def = defaultValue === undefined ? 0.0 : defaultValue
-  if (value === null || value === undefined) {
-    return def
-  }
-  const result = Number.parseFloat(value)
-  return Number.isNaN(result) ? def : result
+): number | Exclude<T, undefined> {
+  // Symbols throw on string coercion, which parseFloat does.
+  const parsedValue = isSymbol(value) ? Number.NaN : Number.parseFloat(value)
+  return Number.isNaN(parsedValue)
+    ? defaultValue !== undefined
+      ? (defaultValue as Exclude<T, undefined>)
+      : 0
+    : parsedValue
 }

--- a/src/number/toInt.ts
+++ b/src/number/toInt.ts
@@ -1,11 +1,23 @@
-export function toInt<T extends number | null = number>(
+import { isSymbol } from 'radashi'
+
+export function toInt(value: unknown): number
+
+export function toInt(value: unknown, defaultValue: number): number
+
+export function toInt<T>(
+  value: unknown,
+  defaultValue: T,
+): number | Exclude<T, undefined>
+
+export function toInt<T>(
   value: any,
   defaultValue?: T,
-): number | T {
-  const def = defaultValue === undefined ? 0 : defaultValue
-  if (value === null || value === undefined) {
-    return def
-  }
-  const result = Number.parseInt(value)
-  return Number.isNaN(result) ? def : result
+): number | Exclude<T, undefined> {
+  // Symbols throw on string coercion, which parseInt does.
+  const parsedValue = isSymbol(value) ? Number.NaN : Number.parseInt(value)
+  return Number.isNaN(parsedValue)
+    ? defaultValue !== undefined
+      ? (defaultValue as Exclude<T, undefined>)
+      : 0
+    : parsedValue
 }

--- a/tests/number/toFloat.test.ts
+++ b/tests/number/toFloat.test.ts
@@ -2,20 +2,16 @@ import * as _ from 'radashi'
 
 describe('toFloat', () => {
   test('handles null', () => {
-    const result = _.toFloat(null)
-    expect(result).toBe(0.0)
+    expect(_.toFloat(null)).toBe(0.0)
   })
   test('handles undefined', () => {
-    const result = _.toFloat(undefined)
-    expect(result).toBe(0.0)
+    expect(_.toFloat(undefined)).toBe(0.0)
   })
   test('uses null default', () => {
-    const result = _.toFloat('x', null)
-    expect(result).toBeNull()
+    expect(_.toFloat('x', null)).toBeNull()
   })
   test('handles bad input', () => {
-    const result = _.toFloat({})
-    expect(result).toBe(0.0)
+    expect(_.toFloat({})).toBe(0.0)
   })
   test('do not throw on symbols', () => {
     expect(_.toFloat(Symbol())).toBe(0)

--- a/tests/number/toFloat.test.ts
+++ b/tests/number/toFloat.test.ts
@@ -17,8 +17,17 @@ describe('toFloat', () => {
     const result = _.toFloat({})
     expect(result).toBe(0.0)
   })
-  test('converts 20.00 correctly', () => {
-    const result = _.toFloat('20.00')
-    expect(result).toBe(20.0)
+  test('do not throw on symbols', () => {
+    expect(_.toFloat(Symbol())).toBe(0)
+  })
+  test('convert "12.34" to 12.34', () => {
+    expect(_.toFloat('12.34')).toBe(12.34)
+  })
+  test('preserve infinite values', () => {
+    expect(_.toFloat(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY)
+    expect(_.toFloat(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY)
+  })
+  test('convert NaN to default', () => {
+    expect(_.toFloat(Number.NaN, 1)).toBe(1)
   })
 })

--- a/tests/number/toInt.test.ts
+++ b/tests/number/toInt.test.ts
@@ -2,20 +2,16 @@ import * as _ from 'radashi'
 
 describe('toInt', () => {
   test('handles null', () => {
-    const result = _.toInt(null)
-    expect(result).toBe(0)
+    expect(_.toInt(null)).toBe(0)
   })
   test('uses null default', () => {
-    const result = _.toInt('x', null)
-    expect(result).toBeNull()
+    expect(_.toInt('x', null)).toBeNull()
   })
   test('handles undefined', () => {
-    const result = _.toInt(undefined)
-    expect(result).toBe(0)
+    expect(_.toInt(undefined)).toBe(0)
   })
   test('handles bad input', () => {
-    const result = _.toInt({})
-    expect(result).toBe(0)
+    expect(_.toInt({})).toBe(0)
   })
   test('do not throw on symbols', () => {
     expect(_.toInt(Symbol())).toBe(0)

--- a/tests/number/toInt.test.ts
+++ b/tests/number/toInt.test.ts
@@ -17,31 +17,20 @@ describe('toInt', () => {
     const result = _.toInt({})
     expect(result).toBe(0)
   })
-  test('converts 20 correctly', () => {
-    const result = _.toInt('20')
-    expect(result).toBe(20)
+  test('do not throw on symbols', () => {
+    expect(_.toInt(Symbol())).toBe(0)
   })
-})
-
-describe('isInt', () => {
-  class Data {}
-  test('returns false for non-number values', () => {
-    expect(_.isInt(undefined)).toBeFalsy()
-    expect(_.isInt(null)).toBeFalsy()
-    expect(_.isInt(false)).toBeFalsy()
-    expect(_.isInt(new Data())).toBeFalsy()
-    expect(_.isInt(Number.NaN)).toBeFalsy()
-    expect(_.isInt([1, 2, 3])).toBeFalsy()
-    expect(_.isInt({})).toBeFalsy()
-    expect(_.isInt('abc')).toBeFalsy()
-    expect(_.isInt(String('abc'))).toBeFalsy()
+  test('convert "20" to 20', () => {
+    expect(_.toInt('20')).toBe(20)
   })
-  test('returns true for int', () => {
-    const result = _.isInt(22)
-    expect(result).toBeTruthy()
+  test('convert 1.23 to 1', () => {
+    expect(_.toInt(1.23)).toBe(1)
   })
-  test('returns false for float', () => {
-    const result = _.isInt(22.0567)
-    expect(result).toBeFalsy()
+  test('convert infinite values to default', () => {
+    expect(_.toInt(Number.POSITIVE_INFINITY, 1)).toBe(1)
+    expect(_.toInt(Number.NEGATIVE_INFINITY, 1)).toBe(1)
+  })
+  test('convert NaN to default', () => {
+    expect(_.toInt(Number.NaN, 1)).toBe(1)
   })
 })


### PR DESCRIPTION
- fix(toInt): avoid throwing on symbol input
- fix(toFloat): avoid throwing on symbol input
- chore: simplify tests

<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Both `toInt` and `toFloat` should handle any possible input, including symbols. They were throwing on symbols, so I've fixed it. I've also cleaned up the implementations beyond that. I'm also using TypeScript overload syntax to prevent a weird return type of `number | number` and it now allows any value type to be the default value.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
