### PR TITLE
test: use fake timers in tests

### DIFF
--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -2,13 +2,10 @@ import * as _ from 'radashi'
 import { AggregateError } from 'radashi'
 
 describe('parallel', () => {
-  beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-  })
   test('returns all results from all functions', async () => {
     const [errors, results] = await _.try(async () => {
       return _.parallel(1, _.list(1, 3), async num => {
-        await _.sleep(1000)
+        await _.sleep(0)
         return `hi_${num}`
       })
     })()
@@ -18,7 +15,7 @@ describe('parallel', () => {
   test('throws errors as array of all errors', async () => {
     const [error, results] = await _.try(async () => {
       return _.parallel(1, _.list(1, 3), async num => {
-        await _.sleep(1000)
+        await _.sleep(0)
         if (num === 2) {
           throw new Error('number is 2')
         }
@@ -36,7 +33,7 @@ describe('parallel', () => {
     await _.parallel(3, _.list(1, 14), async () => {
       numInProgress++
       tracking.push(numInProgress)
-      await _.sleep(300)
+      await _.sleep(0)
       numInProgress--
     })
     expect(Math.max(...tracking)).toBe(3)

--- a/tests/async/sleep.test.ts
+++ b/tests/async/sleep.test.ts
@@ -2,12 +2,14 @@ import * as _ from 'radashi'
 
 describe('sleep', () => {
   beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.useFakeTimers()
   })
   test('suspends a thread for a specified number of milliseconds', async () => {
     const ONE_SECOND = 1000
     const before = Date.now()
-    await _.sleep(ONE_SECOND)
+    const promise = _.sleep(ONE_SECOND)
+    vi.advanceTimersToNextTimerAsync()
+    await promise
     const after = Date.now()
     expect(after).toBeGreaterThanOrEqual(before + ONE_SECOND)
   })

--- a/tests/curry/debounce.test.ts
+++ b/tests/curry/debounce.test.ts
@@ -9,9 +9,11 @@ describe('debounce', () => {
     func()
     func()
   }
+  const delay = 600
 
   beforeEach(() => {
-    func = _.debounce({ delay: 600 }, mockFunc)
+    vi.useFakeTimers()
+    func = _.debounce({ delay }, mockFunc)
   })
 
   afterEach(() => {
@@ -21,7 +23,7 @@ describe('debounce', () => {
   test('only executes once when called rapidly', async () => {
     runFunc3Times()
     expect(mockFunc).toHaveBeenCalledTimes(0)
-    await _.sleep(610)
+    vi.advanceTimersByTime(delay + 10)
     expect(mockFunc).toHaveBeenCalledTimes(1)
   })
 
@@ -47,7 +49,7 @@ describe('debounce', () => {
     expect(mockFunc).toHaveBeenCalledTimes(1)
     func()
     expect(mockFunc).toHaveBeenCalledTimes(1)
-    await _.sleep(610)
+    vi.advanceTimersByTime(delay + 10)
     expect(mockFunc).toHaveBeenCalledTimes(2)
     func.flush()
     expect(mockFunc).toHaveBeenCalledTimes(3)
@@ -58,11 +60,11 @@ describe('debounce', () => {
     func()
     results.push(func.isPending())
     results.push(func.isPending())
-    await _.sleep(610)
+    vi.advanceTimersByTime(delay + 10)
     results.push(func.isPending())
     func()
     results.push(func.isPending())
-    await _.sleep(610)
+    vi.advanceTimersByTime(delay + 10)
     results.push(func.isPending())
     assert.deepEqual(results, [true, true, false, true, false])
   })
@@ -70,7 +72,7 @@ describe('debounce', () => {
   test('returns if there is any pending invocation when the pending method is called', async () => {
     func()
     func.cancel()
-    await _.sleep(610)
+    vi.advanceTimersByTime(delay + 10)
     expect(mockFunc).toHaveBeenCalledTimes(0)
   })
 })

--- a/tests/curry/memo.test.ts
+++ b/tests/curry/memo.test.ts
@@ -24,20 +24,22 @@ describe('memo', () => {
     expect(resultB).not.toBe(resultA)
   })
   test('calls function again when first value expires', async () => {
+    vi.useFakeTimers()
     const func = _.memo(() => new Date().getTime(), {
       ttl: 1,
     })
     const resultA = func()
-    await new Promise(res => setTimeout(res, 100))
+    vi.advanceTimersByTime(100)
     const resultB = func()
     expect(resultA).not.toBe(resultB)
   })
   test('does not call function again when first value has not expired', async () => {
+    vi.useFakeTimers()
     const func = _.memo(() => new Date().getTime(), {
       ttl: 1000,
     })
     const resultA = func()
-    await new Promise(res => setTimeout(res, 100))
+    vi.advanceTimersByTime(100)
     const resultB = func()
     expect(resultA).toBe(resultB)
   })

--- a/tests/curry/throttle.test.ts
+++ b/tests/curry/throttle.test.ts
@@ -1,14 +1,20 @@
 import * as _ from 'radashi'
 
 describe('throttle', () => {
+  const interval = 600
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
   test('throttles!', async () => {
     let calls = 0
-    const func = _.throttle({ interval: 600 }, () => calls++)
+    const func = _.throttle({ interval }, () => calls++)
     func()
     func()
     func()
     expect(calls).toBe(1)
-    await _.sleep(610)
+    vi.advanceTimersByTime(interval + 10)
     func()
     func()
     func()
@@ -17,7 +23,7 @@ describe('throttle', () => {
 
   test('returns if the throttle is active', async () => {
     const results = []
-    const func = _.throttle({ interval: 600 }, () => {})
+    const func = _.throttle({ interval }, () => {})
     results.push(func.isThrottled())
     func()
     results.push(func.isThrottled())
@@ -25,7 +31,7 @@ describe('throttle', () => {
     results.push(func.isThrottled())
     func()
     results.push(func.isThrottled())
-    await _.sleep(610)
+    vi.advanceTimersByTime(interval + 10)
     results.push(func.isThrottled())
     assert.deepEqual(results, [false, true, true, true, false])
   })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

Speeds up test runs by ~5-10 seconds by using [Vitest fake timers](https://vitest.dev/api/vi.html#vi-usefaketimers) to simulate the passage of time.

Before:
<img width="186" alt="Screenshot 2024-07-02 at 11 50 41 PM" src="https://github.com/radashi-org/radashi/assets/18332856/cd2d7d48-f5f3-4d35-8057-7e208ff987b9">

After:
<img width="176" alt="Screenshot 2024-07-02 at 11 49 27 PM" src="https://github.com/radashi-org/radashi/assets/18332856/68917029-b670-43ed-924f-1249e72e4352">




## Related issue, if any:

Resolves https://github.com/radashi-org/radashi/issues/21

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [X] Related documentation has been updated, if needed
- [X] Related tests have been added or updated, if needed
- [X] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
