### PR TITLE
fix!: remove handling of types not present in type signatures

### DIFF
--- a/docs/object/clone.mdx
+++ b/docs/object/clone.mdx
@@ -6,7 +6,9 @@ since: 12.1.0
 
 ### Usage
 
-Creates a shallow copy of the given object/value.
+Creates a shallow copy of the given object or array.
+
+Notably, built-in objects like `Map`, `Set`, `Date`, and others are not supported.
 
 ```ts
 import * as _ from 'radashi'
@@ -21,3 +23,9 @@ const gods = [ra]
 _.clone(ra) // => copy of ra
 _.clone(gods) // => copy of gods
 ```
+
+### Differences from spread syntax
+
+The `clone` function is similar to spread syntax (e.g. `{...obj}`), but it also preserves the prototype of the original object. If a `constructor` property exists on the original prototype, it will be called with the `new` keyword to create a new instance, and all properties will then be copied over to it.
+
+Unlike spread syntax, `clone` also supports cloning arrays.

--- a/src/array/alphabetical.ts
+++ b/src/array/alphabetical.ts
@@ -10,9 +10,6 @@ export function alphabetical<T>(
   getter: (item: T) => string,
   direction: 'asc' | 'desc' = 'asc',
 ): T[] {
-  if (!array) {
-    return []
-  }
   const asc = (a: T, b: T) => `${getter(a)}`.localeCompare(getter(b))
   const dsc = (a: T, b: T) => `${getter(b)}`.localeCompare(getter(a))
   return array.slice().sort(direction === 'desc' ? dsc : asc)

--- a/src/array/boil.ts
+++ b/src/array/boil.ts
@@ -14,8 +14,5 @@ export function boil<T>(
   array: readonly T[],
   compareFunc: (a: T, b: T) => T,
 ): T | null {
-  if (!array || (array.length ?? 0) === 0) {
-    return null
-  }
-  return array.reduce(compareFunc)
+  return array.length ? array.reduce(compareFunc) : null
 }

--- a/src/array/counting.ts
+++ b/src/array/counting.ts
@@ -14,9 +14,6 @@ export function counting<T, TId extends string | number | symbol>(
   array: readonly T[],
   identity: (item: T) => TId,
 ): Record<TId, number> {
-  if (!array) {
-    return {} as Record<TId, number>
-  }
   return array.reduce(
     (acc, item) => {
       const id = identity(item)

--- a/src/array/diff.ts
+++ b/src/array/diff.ts
@@ -19,15 +19,6 @@ export function diff<T>(
   identity: (item: T) => string | number | symbol = (t: T) =>
     t as unknown as string | number | symbol,
 ): T[] {
-  if (!root?.length && !other?.length) {
-    return []
-  }
-  if (root?.length === undefined) {
-    return [...other]
-  }
-  if (!other?.length) {
-    return [...root]
-  }
   const bKeys = other.reduce(
     (acc, item) => {
       acc[identity(item)] = true

--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -21,5 +21,5 @@ export function first<
 ): TArray extends readonly [infer TFirst, ...any[]]
   ? TFirst
   : TArray[number] | TDefault {
-  return array?.length > 0 ? array[0] : defaultValue
+  return array.length > 0 ? array[0] : defaultValue
 }

--- a/src/array/fork.ts
+++ b/src/array/fork.ts
@@ -15,10 +15,8 @@ export function fork<T>(
   condition: (item: T) => boolean,
 ): [T[], T[]] {
   const forked: [T[], T[]] = [[], []]
-  if (array) {
-    for (const item of array) {
-      forked[condition(item) ? 0 : 1].push(item)
-    }
+  for (const item of array) {
+    forked[condition(item) ? 0 : 1].push(item)
   }
   return forked
 }

--- a/src/array/intersects.ts
+++ b/src/array/intersects.ts
@@ -17,9 +17,6 @@ export function intersects<T, K>(
   listB: readonly T[],
   identity?: (t: T) => K,
 ): boolean {
-  if (!listA || !listB) {
-    return false
-  }
   if (identity) {
     const known = new Set(listA.map(identity))
     return listB.some(item => known.has(identity(item)))

--- a/src/array/last.ts
+++ b/src/array/last.ts
@@ -21,5 +21,5 @@ export function last<
 ): TArray extends readonly [...any[], infer TLast]
   ? TLast
   : TArray[number] | TDefault {
-  return array?.length > 0 ? array[array.length - 1] : defaultValue
+  return array.length > 0 ? array[array.length - 1] : defaultValue
 }

--- a/src/array/merge.ts
+++ b/src/array/merge.ts
@@ -20,18 +20,6 @@ export function merge<T>(
   array: readonly T[],
   toKey: (item: T) => any,
 ): T[] {
-  if (!array && !prev) {
-    return []
-  }
-  if (!array) {
-    return [...prev]
-  }
-  if (!prev) {
-    return []
-  }
-  if (!toKey) {
-    return [...prev]
-  }
   const keys = new Map()
   for (const item of array) {
     keys.set(toKey(item), item)

--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -15,9 +15,6 @@ export function replace<T>(
   newItem: T,
   match: (item: T, idx: number) => boolean,
 ): T[] {
-  if (!array) {
-    return []
-  }
   if (newItem === undefined) {
     return [...array]
   }

--- a/src/array/replace.ts
+++ b/src/array/replace.ts
@@ -1,3 +1,6 @@
+// biome-ignore lint/complexity/noBannedTypes: {} represents “all types but null/undefined”
+type Defined<T> = T & ({} | null)
+
 /**
  * Replace an element in an array with a new item without modifying
  * the array and return the new value.
@@ -10,15 +13,15 @@
  * ```
  * @version 12.1.0
  */
-export function replace<T>(
+export function replace<T, U>(
   array: readonly T[],
-  newItem: T,
+  newItem: U,
   match: (item: T, idx: number) => boolean,
-): T[] {
+): (T | Defined<U>)[] {
   if (newItem === undefined) {
     return [...array]
   }
-  const out = array.slice()
+  const out = array.slice() as (T | Defined<U>)[]
   for (let index = 0; index < array.length; index++) {
     if (match(array[index], index)) {
       out[index] = newItem

--- a/src/array/replaceOrAppend.ts
+++ b/src/array/replaceOrAppend.ts
@@ -19,14 +19,8 @@ export function replaceOrAppend<T>(
   newItem: T,
   match: (a: T, idx: number) => boolean,
 ): T[] {
-  if (!array && !newItem) {
-    return []
-  }
-  if (!newItem) {
+  if (newItem === undefined) {
     return [...array]
-  }
-  if (!array) {
-    return [newItem]
   }
   const out = array.slice()
   for (let index = 0; index < array.length; index++) {

--- a/src/array/replaceOrAppend.ts
+++ b/src/array/replaceOrAppend.ts
@@ -25,7 +25,7 @@ export function replaceOrAppend<T, U>(
   if (newItem === undefined) {
     return [...array]
   }
-  const out = array.slice()
+  const out = array.slice() as (T | Defined<U>)[]
   for (let index = 0; index < array.length; index++) {
     if (match(array[index], index)) {
       out[index] = newItem

--- a/src/array/replaceOrAppend.ts
+++ b/src/array/replaceOrAppend.ts
@@ -1,3 +1,6 @@
+// biome-ignore lint/complexity/noBannedTypes: {} represents “all types but null/undefined”
+type Defined<T> = T & ({} | null)
+
 /**
  * Replace the first occurrence of an item in an array where the
  * `match` function returns true. If no items match, append the new
@@ -14,11 +17,11 @@
  * ```
  * @version 12.1.0
  */
-export function replaceOrAppend<T>(
+export function replaceOrAppend<T, U>(
   array: readonly T[],
-  newItem: T,
+  newItem: U,
   match: (a: T, idx: number) => boolean,
-): T[] {
+): (T | Defined<U>)[] {
   if (newItem === undefined) {
     return [...array]
   }

--- a/src/array/select.ts
+++ b/src/array/select.ts
@@ -31,9 +31,6 @@ export function select<T, U>(
   mapper: (item: T, index: number) => U,
   condition?: ((item: T, index: number) => boolean) | null,
 ): U[] {
-  if (!array) {
-    return []
-  }
   let mapped: U
   return array.reduce((acc, item, index) => {
     if (condition) {

--- a/src/array/selectFirst.ts
+++ b/src/array/selectFirst.ts
@@ -20,9 +20,6 @@ export function selectFirst<T, U>(
   mapper: (item: T, index: number) => U,
   condition?: (item: T, index: number) => boolean,
 ): U | undefined {
-  if (!array) {
-    return undefined
-  }
   let foundIndex = -1
   const found = array.find((item, index) => {
     foundIndex = index

--- a/src/array/sort.ts
+++ b/src/array/sort.ts
@@ -21,9 +21,6 @@ export function sort<T>(
   getter: (item: T) => number,
   desc = false,
 ): T[] {
-  if (!array) {
-    return []
-  }
   const asc = (a: T, b: T) => getter(a) - getter(b)
   const dsc = (a: T, b: T) => getter(b) - getter(a)
   return array.slice().sort(desc === true ? dsc : asc)

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -42,9 +42,6 @@ export function toggle<T>(
     strategy?: 'prepend' | 'append'
   },
 ): T[] {
-  if (!array) {
-    return item !== undefined ? [item] : []
-  }
   if (item === undefined) {
     return [...array]
   }

--- a/src/array/unzip.ts
+++ b/src/array/unzip.ts
@@ -13,9 +13,6 @@
  * @version 12.2.0
  */
 export function unzip<T>(arrays: readonly (readonly T[])[]): T[][] {
-  if (!arrays || !arrays.length) {
-    return []
-  }
   const out = new Array(
     arrays.reduce((max, arr) => Math.max(max, arr.length), 0),
   )

--- a/src/array/zipToObject.ts
+++ b/src/array/zipToObject.ts
@@ -22,10 +22,6 @@ export function zipToObject<K extends string | number | symbol, V>(
   keys: readonly K[],
   values: V | ((key: K, idx: number) => V) | readonly V[],
 ): Record<K, V> {
-  if (!keys || !keys.length) {
-    return {} as Record<K, V>
-  }
-
   const getValue = isFunction(values)
     ? values
     : isArray(values)

--- a/src/async/map.ts
+++ b/src/async/map.ts
@@ -17,9 +17,6 @@ export async function map<T, K>(
   array: readonly T[],
   asyncMapFunc: (item: T, index: number) => PromiseLike<K>,
 ): Promise<K[]> {
-  if (!array) {
-    return []
-  }
   const result = []
   let index = 0
   for (const value of array) {

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -25,9 +25,6 @@ export async function reduce<T, K>(
   reducer: (acc: K, item: T, index: number) => Promise<K>,
   initialValue?: K,
 ): Promise<K> {
-  if (!array) {
-    array = []
-  }
   const indices = array.keys()
   let acc = initialValue
   // biome-ignore lint/style/noArguments:

--- a/src/number/inRange.ts
+++ b/src/number/inRange.ts
@@ -34,20 +34,7 @@ export function inRange(number: number, end: number): boolean
  * ```
  */
 export function inRange(number: number, start: number, end: number): boolean
-export function inRange(number: number, start: number, end?: number): boolean {
-  const isTypeSafe =
-    typeof number === 'number' &&
-    typeof start === 'number' &&
-    (typeof end === 'undefined' || typeof end === 'number')
 
-  if (!isTypeSafe) {
-    return false
-  }
-
-  if (typeof end === 'undefined') {
-    end = start
-    start = 0
-  }
-
+export function inRange(number: number, start: number, end = 0): boolean {
   return number >= Math.min(start, end) && number < Math.max(start, end)
 }

--- a/src/number/max.ts
+++ b/src/number/max.ts
@@ -19,7 +19,7 @@ export function max<T>(
   array: readonly T[],
   getter?: (item: T) => number,
 ): T | null {
-  if (!array || (array.length ?? 0) === 0) {
+  if (!array.length) {
     return null
   }
   const get = getter ?? ((v: any) => v)

--- a/src/number/min.ts
+++ b/src/number/min.ts
@@ -19,7 +19,7 @@ export function min<T>(
   array: readonly T[],
   getter?: (item: T) => number,
 ): T | null {
-  if (!array || (array.length ?? 0) === 0) {
+  if (!array.length) {
     return null
   }
   const get = getter ?? ((v: any) => v)

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -27,9 +27,6 @@ export function assign<
   TInitial extends Record<keyof any, any>,
   TOverride extends Record<keyof any, any>,
 >(initial: TInitial, override: TOverride): Assign<TInitial, TOverride> {
-  if (!initial || !override) {
-    return (initial ?? override ?? {}) as any
-  }
   const proto = Object.getPrototypeOf(initial)
   const merged = proto
     ? { ...initial }

--- a/src/object/clone.ts
+++ b/src/object/clone.ts
@@ -1,5 +1,3 @@
-import { isPrimitive } from 'radashi'
-
 /**
  * Creates a shallow copy of the given object/value.
  *
@@ -16,17 +14,7 @@ import { isPrimitive } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function clone<T>(obj: T): T {
-  // Primitive values do not need cloning.
-  if (isPrimitive(obj)) {
-    return obj
-  }
-
-  // Binding a function to an empty object creates a copy function.
-  if (typeof obj === 'function') {
-    return obj.bind({})
-  }
-
+export function clone<T extends object>(obj: T): T {
   const proto = Object.getPrototypeOf(obj)
   const newObj =
     typeof proto?.constructor === 'function'

--- a/src/object/construct.ts
+++ b/src/object/construct.ts
@@ -13,9 +13,6 @@ import { set } from 'radashi'
  * @version 12.1.0
  */
 export function construct<TObject extends object>(obj: TObject): object {
-  if (!obj) {
-    return {}
-  }
   return Object.keys(obj).reduce((acc, path) => {
     return set(acc, path, (obj as any)[path])
   }, {})

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -13,9 +13,6 @@ import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
  * @version 12.1.0
  */
 export function crush<T extends object>(value: T): Crush<T> {
-  if (!value) {
-    return {} as Crush<T>
-  }
   return (function crushReducer(
     crushed: Crush<T>,
     value: unknown,

--- a/src/object/invert.ts
+++ b/src/object/invert.ts
@@ -15,9 +15,6 @@ export function invert<
   TKey extends string | number | symbol,
   TValue extends string | number | symbol,
 >(obj: Record<TKey, TValue>): Record<TValue, TKey> {
-  if (!obj) {
-    return {} as Record<TValue, TKey>
-  }
   const keys = Object.keys(obj) as TKey[]
   return keys.reduce(
     (acc, key) => {

--- a/src/object/keys.ts
+++ b/src/object/keys.ts
@@ -14,9 +14,6 @@ import { isArray, isPlainObject } from 'radashi'
  * @version 12.1.0
  */
 export function keys(value: object): string[] {
-  if (!value) {
-    return []
-  }
   const keys: string[] = []
   const keyPath: (string | number)[] = []
   const recurse = (value: any) => {

--- a/src/object/listify.ts
+++ b/src/object/listify.ts
@@ -18,14 +18,7 @@ export function listify<Value, Key extends string | number | symbol, Item>(
   obj: Record<Key, Value>,
   toItem: (key: Key, value: Value) => Item,
 ): Item[] {
-  if (!obj) {
-    return []
-  }
-  const entries = Object.entries(obj)
-  if (entries.length === 0) {
-    return []
-  }
-  return entries.reduce((acc, entry) => {
+  return Object.entries(obj).reduce((acc, entry) => {
     acc.push(toItem(entry[0] as Key, entry[1] as Value))
     return acc
   }, [] as Item[])

--- a/src/object/mapEntries.ts
+++ b/src/object/mapEntries.ts
@@ -19,9 +19,6 @@ export function mapEntries<
   obj: Record<TKey, TValue>,
   toEntry: (key: TKey, value: TValue) => [TNewKey, TNewValue],
 ): Record<TNewKey, TNewValue> {
-  if (!obj) {
-    return {} as Record<TNewKey, TNewValue>
-  }
   return Object.entries(obj).reduce(
     (acc, [key, value]) => {
       const [newKey, newValue] = toEntry(key as TKey, value as TValue)

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -15,10 +15,7 @@ export function omit<T, TKeys extends keyof T>(
   obj: T,
   keys: readonly TKeys[],
 ): Omit<T, TKeys> {
-  if (!obj) {
-    return {} as Omit<T, TKeys>
-  }
-  if (!keys || keys.length === 0) {
+  if (keys.length === 0) {
     return obj as Omit<T, TKeys>
   }
   return keys.reduce(

--- a/src/object/pick.ts
+++ b/src/object/pick.ts
@@ -31,9 +31,6 @@ export function pick<T extends object>(
   obj: T,
   filter: KeyFilter<T, keyof T> | null,
 ) {
-  if (!obj) {
-    return {}
-  }
   let keys: (keyof T)[] = filter as any
   if (isArray(filter)) {
     filter = null

--- a/src/object/set.ts
+++ b/src/object/set.ts
@@ -17,24 +17,17 @@ export function set<T extends object, K>(
   path: string,
   value: K,
 ): T {
-  if (!initial) {
-    return {} as T
-  }
-  if (!path || value === undefined) {
+  if (value === undefined) {
     return initial
   }
-
   const root: any = clone(initial)
   const keys = path.match(/[^.[\]]+/g)
-  if (keys) {
-    keys.reduce(
-      (object, key, i) =>
-        i < keys.length - 1
-          ? (object[key] ??= isIntString(keys[i + 1]) ? [] : {})
-          : (object[key] = value),
-      root,
-    )
-  }
-
+  keys?.reduce(
+    (object, key, i) =>
+      i < keys.length - 1
+        ? (object[key] ??= isIntString(keys[i + 1]) ? [] : {})
+        : (object[key] = value),
+    root,
+  )
   return root
 }

--- a/src/object/shake.ts
+++ b/src/object/shake.ts
@@ -28,9 +28,6 @@ export function shake<T extends object>(
   obj: T,
   filter: (value: unknown) => boolean = value => value === undefined,
 ): T {
-  if (!obj) {
-    return {} as T
-  }
   return (Object.keys(obj) as (keyof T)[]).reduce((acc, key) => {
     if (!filter(obj[key])) {
       acc[key] = obj[key]

--- a/src/string/camel.ts
+++ b/src/string/camel.ts
@@ -13,17 +13,11 @@ import { capitalize } from 'radashi'
  * @version 12.1.0
  */
 export function camel(str: string): string {
-  const parts =
-    str
-      ?.replace(/([A-Z])+/g, capitalize)
-      ?.split(/(?=[A-Z])|[\.\-\s_]/)
-      .map(x => x.toLowerCase()) ?? []
-  if (parts.length === 0) {
-    return ''
-  }
-  if (parts.length === 1) {
-    return parts[0]
-  }
+  const parts = str
+    .replace(/([A-Z])+/g, capitalize)
+    .split(/(?=[A-Z])|[\.\-\s_]/)
+    .map(x => x.toLowerCase())
+
   return parts.reduce((acc, part) => {
     return `${acc}${part.charAt(0).toUpperCase()}${part.slice(1)}`
   })

--- a/src/string/capitalize.ts
+++ b/src/string/capitalize.ts
@@ -10,9 +10,6 @@
  * @version 12.1.0
  */
 export function capitalize(str: string): string {
-  if (!str || str.length === 0) {
-    return ''
-  }
   const lower = str.toLowerCase()
   return lower.substring(0, 1).toUpperCase() + lower.substring(1, lower.length)
 }

--- a/src/string/dash.ts
+++ b/src/string/dash.ts
@@ -13,17 +13,11 @@ import { capitalize } from 'radashi'
  * @version 12.1.0
  */
 export function dash(str: string): string {
-  const parts =
-    str
-      ?.replace(/([A-Z])+/g, capitalize)
-      ?.split(/(?=[A-Z])|[\.\-\s_]/)
-      .map(x => x.toLowerCase()) ?? []
-  if (parts.length === 0) {
-    return ''
-  }
-  if (parts.length === 1) {
-    return parts[0]
-  }
+  const parts = str
+    .replace(/([A-Z])+/g, capitalize)
+    .split(/(?=[A-Z])|[\.\-\s_]/)
+    .map(x => x.toLowerCase())
+
   return parts.reduce((acc, part) => {
     return `${acc}-${part.toLowerCase()}`
   })

--- a/src/string/pascal.ts
+++ b/src/string/pascal.ts
@@ -11,10 +11,6 @@
  * @version 12.1.0
  */
 export function pascal(str: string): string {
-  if (!str) {
-    return ''
-  }
-
   const result = str.replace(
     /(?:[^\w\d]|_|\s)+(\w)([A-Z]+)?/g,
     (_, firstCharacter, capitalizedLetters) => {

--- a/src/string/snake.ts
+++ b/src/string/snake.ts
@@ -18,21 +18,16 @@ export function snake(
     splitOnNumber?: boolean
   },
 ): string {
-  const parts =
-    str
-      ?.replace(/([A-Z])+/g, capitalize)
-      .split(/(?=[A-Z])|[\.\-\s_]/)
-      .map(x => x.toLowerCase()) ?? []
-  if (parts.length === 0) {
-    return ''
-  }
-  if (parts.length === 1) {
-    return parts[0]
-  }
+  const parts = str
+    .replace(/([A-Z])+/g, capitalize)
+    .split(/(?=[A-Z])|[\.\-\s_]/)
+    .map(x => x.toLowerCase())
+
   const result = parts.reduce((acc, part) => {
     return `${acc}_${part.toLowerCase()}`
   })
+
   return options?.splitOnNumber === false
     ? result
-    : result.replace(/([A-Za-z]{1}[0-9]{1})/, val => `${val[0]!}_${val[1]!}`)
+    : result.replace(/([A-Za-z]{1}[0-9]{1})/, val => `${val[0]}_${val[1]}`)
 }

--- a/src/string/title.ts
+++ b/src/string/title.ts
@@ -13,10 +13,7 @@ import { capitalize } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function title(str: string | null | undefined): string {
-  if (!str) {
-    return ''
-  }
+export function title(str: string): string {
   return str
     .split(/(?=[A-Z])|[\.\-\s_]/)
     .map(s => s.trim())

--- a/src/string/trim.ts
+++ b/src/string/trim.ts
@@ -13,13 +13,7 @@
  * ```
  * @version 12.1.0
  */
-export function trim(
-  str: string | null | undefined,
-  charsToTrim = ' ',
-): string {
-  if (!str) {
-    return ''
-  }
+export function trim(str: string, charsToTrim = ' '): string {
   const toTrim = charsToTrim.replace(/[\W]{1}/g, '\\$&')
   const regex = new RegExp(`^[${toTrim}]+|[${toTrim}]+$`, 'g')
   return str.replace(regex, '')

--- a/tests/array/alphabetical.test.ts
+++ b/tests/array/alphabetical.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = (value: any) => value as string[]
-
 describe('alphabetical', () => {
   test('uses getter', () => {
     const list = [{ name: 'Leo' }, { name: 'AJ' }, { name: 'Cynthia' }]
@@ -16,9 +14,5 @@ describe('alphabetical', () => {
     expect(result[0].name).toBe('Leo')
     expect(result[1].name).toBe('Cynthia')
     expect(result[2].name).toBe('AJ')
-  })
-  test('gracefully handles null input list', () => {
-    const result = _.alphabetical(cast(null), x => x)
-    expect(result).toEqual([])
   })
 })

--- a/tests/array/boil.test.ts
+++ b/tests/array/boil.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('boil', () => {
   test('compares and keeps item based on condition', () => {
     const list = [
@@ -17,14 +15,6 @@ describe('boil', () => {
   })
   test('does not fail when provided array is empty', () => {
     const result = _.boil([], () => true)
-    expect(result).toBeNull()
-  })
-  test('does not fail when provided array is null', () => {
-    const result = _.boil(cast(null), () => true)
-    expect(result).toBeNull()
-  })
-  test('does not fail when provided array is funky shaped', () => {
-    const result = _.boil(cast({}), () => true)
     expect(result).toBeNull()
   })
 })

--- a/tests/array/counting.test.ts
+++ b/tests/array/counting.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = number[]>(value: any): T => value
-
 describe('counting', () => {
   const people = [
     { name: 'ray', group: 'X' },
@@ -15,9 +13,5 @@ describe('counting', () => {
       X: 2,
       Y: 2,
     })
-  })
-  test('does not error on bad input', () => {
-    expect(() => _.counting(cast(null), x => x)).not.toThrow()
-    expect(() => _.counting(cast(undefined), x => x)).not.toThrow()
   })
 })

--- a/tests/array/diff.test.ts
+++ b/tests/array/diff.test.ts
@@ -1,20 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('diff', () => {
-  test('handles null root', () => {
-    const result = _.diff(cast(null), ['a'])
-    expect(result).toEqual(['a'])
-  })
-  test('handles null other', () => {
-    const result = _.diff(['a'], cast(null))
-    expect(result).toEqual(['a'])
-  })
-  test('handles null inputs', () => {
-    const result = _.diff(cast(null), cast(null))
-    expect(result).toEqual([])
-  })
   test('handles empty array root', () => {
     const result = _.diff([], ['a'])
     expect(result).toEqual([])

--- a/tests/array/first.test.ts
+++ b/tests/array/first.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = (value: any) => value as unknown[]
-
 describe('first', () => {
   test('returns first item in list', () => {
     const list = [
@@ -16,9 +14,5 @@ describe('first', () => {
     const list = [] as string[]
     const result = _.first(list, 'yolo')
     expect(result).toBe('yolo')
-  })
-  test('gracefully handles null input list', () => {
-    const result = _.first(cast(null))
-    expect(result).toBeUndefined()
   })
 })

--- a/tests/array/fork.test.ts
+++ b/tests/array/fork.test.ts
@@ -1,13 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = (value: any) => value as unknown[]
-
 describe('fork', () => {
-  test('returns two empty arrays for null input', () => {
-    const [a, b] = _.fork(cast(null), x => !!x)
-    expect(a).toEqual([])
-    expect(b).toEqual([])
-  })
   test('returns two empty arrays for one empty array input', () => {
     const [a, b] = _.fork([], x => !!x)
     expect(a).toEqual([])

--- a/tests/array/intersects.test.ts
+++ b/tests/array/intersects.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('intersects', () => {
   test('returns true if list a & b have items in common', () => {
     const listA = ['a', 'b']
@@ -20,10 +18,6 @@ describe('intersects', () => {
     const listB = [{ value: 12 }]
     const result = _.intersects(listA, listB, x => x.value)
     expect(result).toBeTruthy()
-  })
-  test('returns false without failing if either list is null', () => {
-    expect(_.intersects(cast(null), [])).toBeFalsy()
-    expect(_.intersects([], cast(null))).toBeFalsy()
   })
   test('works with objects without an identity function', () => {
     const obj1 = { id: 1 }

--- a/tests/array/last.test.ts
+++ b/tests/array/last.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = (value: any) => value as unknown[]
-
 describe('last', () => {
   test('returns last item in list', () => {
     const list = [
@@ -16,9 +14,5 @@ describe('last', () => {
     const list = [] as string[]
     const result = _.last(list, 'yolo')
     expect(result).toBe('yolo')
-  })
-  test('gracefully handles null input list', () => {
-    const result = _.last(cast(null))
-    expect(result).toBeUndefined()
   })
 })

--- a/tests/array/merge.test.ts
+++ b/tests/array/merge.test.ts
@@ -1,27 +1,9 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any) => value as T
-
 describe('merge', () => {
-  test('returns empty array for two null inputs', () => {
-    const result = _.merge(cast(null), cast(null), _ => '')
-    expect(result).toEqual([])
-  })
   test('returns an empty array for two empty array inputs', () => {
     const result = _.merge([], [], _ => '')
     expect(result).toEqual([])
-  })
-  test('returns root for a null other input', () => {
-    const result = _.merge([], cast(null), _ => '')
-    expect(result).toEqual([])
-  })
-  test('returns empty array for a null root input', () => {
-    const result = _.merge(cast(null), [], _ => '')
-    expect(result).toEqual([])
-  })
-  test('returns root for a null matcher input', () => {
-    const result = _.merge(['a'], [], cast(null))
-    expect(result).toEqual(['a'])
   })
   test('returns correctly merged lists', () => {
     const inputA = [

--- a/tests/array/replace.test.ts
+++ b/tests/array/replace.test.ts
@@ -1,12 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('replace', () => {
-  test('returns empty list for null input list', () => {
-    const result = _.replace(cast(null), 'x', () => false)
-    expect(result).toEqual([])
-  })
   test('returns the list for an undefined new item', () => {
     const result = _.replace(['a'], undefined, () => true)
     expect(result).toEqual(['a'])

--- a/tests/array/replaceOrAppend.test.ts
+++ b/tests/array/replaceOrAppend.test.ts
@@ -1,24 +1,19 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any) => value as T
-
 describe('replaceOrAppend', () => {
   const letters = ['a', 'b', 'c', 'd', 'e']
   const lettersXA = ['XA', 'b', 'c', 'd', 'e']
   const lettersXC = ['a', 'b', 'XC', 'd', 'e']
   const lettersXE = ['a', 'b', 'c', 'd', 'XE']
   const lettersXX = ['a', 'b', 'c', 'd', 'e', 'XX']
-  test('returns empty array for two null inputs', () => {
-    const result = _.replaceOrAppend(cast(null), null, _ => false)
-    expect(result).toEqual([])
-  })
-  test('returns array with new item for null list input', () => {
-    const result = _.replaceOrAppend(cast(null), 'a', _ => false)
+
+  test('returns list for undefined new item input', () => {
+    const result = _.replaceOrAppend(['a'], undefined, _ => false)
     expect(result).toEqual(['a'])
   })
-  test('returns list for null new item input', () => {
-    const result = _.replaceOrAppend(['a'], null, _ => false)
-    expect(result).toEqual(['a'])
+  test('returns replaced item when value is null', () => {
+    const result = _.replaceOrAppend(['a'], null, i => i === 'a')
+    expect(result).toEqual([null])
   })
   test('returns list with item replacing match by index', () => {
     const result = _.replaceOrAppend(

--- a/tests/array/select.test.ts
+++ b/tests/array/select.test.ts
@@ -1,24 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('select', () => {
-  test('does not fail on bad input', () => {
-    expect(
-      _.select(
-        cast(null),
-        x => x,
-        x => x,
-      ),
-    ).toEqual([])
-    expect(
-      _.select(
-        cast(undefined),
-        x => x,
-        x => x,
-      ),
-    ).toEqual([])
-  })
   test('returns mapped and filtered values', () => {
     const list = [
       { group: 'a', word: 'hello' },

--- a/tests/array/selectFirst.test.ts
+++ b/tests/array/selectFirst.test.ts
@@ -1,24 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('selectFirst', () => {
-  test('does not fail on bad input', () => {
-    expect(
-      _.selectFirst(
-        cast(null),
-        x => x,
-        x => x,
-      ),
-    ).toBeUndefined()
-    expect(
-      _.selectFirst(
-        cast(undefined),
-        x => x,
-        x => x,
-      ),
-    ).toBeUndefined()
-  })
   test('returns mapped result of first value that meets the condition', () => {
     const list = [
       { group: 'a', word: 'hello' },

--- a/tests/array/sort.test.ts
+++ b/tests/array/sort.test.ts
@@ -15,8 +15,4 @@ describe('sort', () => {
     expect(result[1].index).toBe(1)
     expect(result[2].index).toBe(0)
   })
-  test('gracefully handles null input list', () => {
-    const result = _.sort(null as any as number[], x => x)
-    expect(result).toEqual([])
-  })
 })

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -1,14 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('toggle', () => {
-  test('should handle null input list', () => {
-    let result = _.toggle(cast(null), 'a')
-    expect(result).toEqual(['a'])
-    result = _.toggle(cast(null), undefined)
-    expect(result).toEqual([])
-  })
   test('should skip undefined item', () => {
     const result = _.toggle(['a'], undefined)
     expect(result).toEqual(['a'])

--- a/tests/array/zipToObject.test.ts
+++ b/tests/array/zipToObject.test.ts
@@ -15,10 +15,4 @@ describe('zipToObject', () => {
     const result = _.zipToObject(['a', 'b'], 1)
     expect(result).toEqual({ a: 1, b: 1 })
   })
-
-  test('returns an empty object if bad parameters are passed', () => {
-    // @ts-ignore
-    const result = _.zipToObject()
-    expect(result).toEqual({})
-  })
 })

--- a/tests/async/map.test.ts
+++ b/tests/async/map.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('map', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
@@ -14,11 +12,6 @@ describe('map', () => {
     }
     const result = await _.map<number, number>(numbers, asyncSquare)
     expect(result).toEqual([1, 4, 9, 16])
-  })
-
-  test('handles null input', async () => {
-    const result = await _.map(cast(null), async () => '')
-    expect(result).toEqual([])
   })
 
   test('passes correct indexes', async () => {

--- a/tests/async/reduce.test.ts
+++ b/tests/async/reduce.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('asyncReduce', () => {
   const numbers = [0, 1, 2, 3, 4]
   const reducer = async (a: number, b: number): Promise<number> => {
@@ -37,10 +35,5 @@ describe('asyncReduce', () => {
     await expect(async () => _.reduce([], reducer)).rejects.toThrowError(
       'Reduce of empty array with no initial value',
     )
-  })
-  test('throws on no init value and a null array input', async () => {
-    await expect(async () =>
-      _.reduce(cast(null), reducer),
-    ).rejects.toThrowError('Reduce of empty array with no initial value')
   })
 })

--- a/tests/number/inRange.test.ts
+++ b/tests/number/inRange.test.ts
@@ -1,19 +1,6 @@
 import * as _ from 'radashi'
 
 describe('inRange', () => {
-  test('handles nullish values', () => {
-    expect(_.inRange(0, 1, null as any)).toBe(false)
-    expect(_.inRange(0, null as any, 1)).toBe(false)
-    expect(_.inRange(null as any, 0, 1)).toBe(false)
-    expect(_.inRange(0, undefined as any, 1)).toBe(false)
-    expect(_.inRange(undefined as any, 0, 1)).toBe(false)
-
-    expect(_.inRange(0, 1, undefined as any)).toBe(true)
-  })
-  test('handles bad input', () => {
-    const result = _.inRange(0, 1, {} as any)
-    expect(result).toBe(false)
-  })
   test('computes correctly', () => {
     expect(_.inRange(10, 0, 5)).toBe(false)
     expect(_.inRange(10, 0, 20)).toBe(true)

--- a/tests/number/max.test.ts
+++ b/tests/number/max.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('max', () => {
   test('returns the max value from list of number', () => {
     const list = [5, 5, 10, 2]
@@ -19,13 +17,5 @@ describe('max', () => {
     const result = _.max(list, x => x.score)
     expect(result!.game).toBe('e')
     expect(result!.score).toBe(500)
-  })
-  test('does not fail when provided array is null', () => {
-    const result = _.max(cast(null))
-    expect(result).toBeNull()
-  })
-  test('does not fail when provided array is funky shaped', () => {
-    const result = _.max(cast({}))
-    expect(result).toBeNull()
   })
 })

--- a/tests/number/max.test.ts
+++ b/tests/number/max.test.ts
@@ -18,4 +18,8 @@ describe('max', () => {
     expect(result!.game).toBe('e')
     expect(result!.score).toBe(500)
   })
+  test('returns null if array is empty', () => {
+    const result = _.max([])
+    expect(result).toBeNull()
+  })
 })

--- a/tests/number/min.test.ts
+++ b/tests/number/min.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = unknown[]>(value: any): T => value
-
 describe('min', () => {
   test('returns the min value from list of number', () => {
     const list = [5, 5, 10, 2]
@@ -19,13 +17,5 @@ describe('min', () => {
     const result = _.min(list, x => x.score)
     expect(result!.game).toBe('a')
     expect(result!.score).toBe(100)
-  })
-  test('does not fail when provided array is null', () => {
-    const result = _.min(cast(null))
-    expect(result).toBeNull()
-  })
-  test('does not fail when provided array is funky shaped', () => {
-    const result = _.min(cast({}))
-    expect(result).toBeNull()
   })
 })

--- a/tests/number/min.test.ts
+++ b/tests/number/min.test.ts
@@ -18,4 +18,8 @@ describe('min', () => {
     expect(result!.game).toBe('a')
     expect(result!.score).toBe(100)
   })
+  test('returns null if array is empty', () => {
+    const result = _.min([])
+    expect(result).toBeNull()
+  })
 })

--- a/tests/object/assign.test.ts
+++ b/tests/object/assign.test.ts
@@ -1,7 +1,5 @@
 import * as _ from 'radashi'
 
-const cast = <T = object>(value: any): T => value
-
 describe('assign', () => {
   const initial = {
     name: 'jay',
@@ -25,18 +23,6 @@ describe('assign', () => {
       },
     },
   }
-  test('handles both null input', () => {
-    const result = _.assign(cast(null), cast(null))
-    expect(result).toEqual({})
-  })
-  test('handles null first input', () => {
-    const result = _.assign({ a: 'y' }, cast(null))
-    expect(result).toEqual({ a: 'y' })
-  })
-  test('handles null last input', () => {
-    const result = _.assign(cast(null), { a: 'y' })
-    expect(result).toEqual({ a: 'y' })
-  })
   test('correctly assign a with values from b', () => {
     const result = _.assign(initial, override)
     expect(result).toEqual(override)

--- a/tests/object/clone.test.ts
+++ b/tests/object/clone.test.ts
@@ -6,24 +6,9 @@ describe('clone', () => {
     const result = _.clone(arr)
 
     expect(arr).not.toBe(result)
-    for (const i in result) {
-      expect(arr[i]).toBe(result[i])
-    }
+    expect(arr).toEqual(result)
   })
-  test('copies objects (class instances) without losing the class type', () => {
-    class Data {
-      val = 0
-    }
-
-    const obj = new Data()
-    obj.val = 1
-    const result = _.clone(obj)
-
-    expect(obj).not.toBe(result)
-    expect(obj.constructor.name).toBe(result.constructor.name)
-    expect(obj.val).toBe(result.val)
-  })
-  test('copies all attributes from object', () => {
+  test('copies plain object in its entirety', () => {
     const obj = {
       x: 22,
       add: (a: number, b: number) => a + b,
@@ -36,21 +21,30 @@ describe('clone', () => {
     expect(result.add(2, 2)).toBe(obj.add(2, 2))
     expect(result.child.key).toBe(obj.child.key)
   })
-  test('copies all attributes from class instance', () => {
+  test('copies properties and prototype from class instance', () => {
     class Data {
-      public x = 22
+      public x = 0
+      public get y() {
+        return this.x + 1
+      }
       public add(a: number, b: number) {
         return a + b
       }
-      public child: any = {
-        key: 'yolo',
-      }
     }
-    const result = _.clone(new Data())
+
+    const data = new Data()
+    data.x = 22
+
+    const result = _.clone(data)
+    expect(result).not.toBe(data)
+    expect(result).toBeInstanceOf(Data)
+
     expect(result.x).toBe(22)
-    // @warning will not copy functions from class instance
-    // expect(result.add(2, 2)).toBe(4)
-    expect(result.child.key).toBe('yolo')
+    expect(result.y).toBe(23)
+
+    // biome-ignore lint/suspicious/noPrototypeBuiltins:
+    expect(result.hasOwnProperty('add')).toBe(false)
+    expect(result.add).toBe(Data.prototype.add)
   })
   test('copies object created with Object.create(null)', () => {
     const obj = Object.create(null)

--- a/tests/object/clone.test.ts
+++ b/tests/object/clone.test.ts
@@ -1,21 +1,6 @@
 import * as _ from 'radashi'
 
 describe('clone', () => {
-  test('copies the primitives', () => {
-    const arr = [
-      1.1,
-      'How you doing?',
-      false,
-      Symbol('key'),
-      BigInt('1'),
-      undefined,
-      null,
-    ]
-    for (const elm of arr) {
-      const newElm = _.clone(elm)
-      expect(elm).toBe(newElm)
-    }
-  })
   test('copies arrays', () => {
     const arr = [{ a: 0 }, 1, 2, 3]
     const result = _.clone(arr)
@@ -24,13 +9,6 @@ describe('clone', () => {
     for (const i in result) {
       expect(arr[i]).toBe(result[i])
     }
-  })
-  test('copies functions', () => {
-    const fa = () => 0
-    const fb = _.clone(fa)
-
-    expect(fa).not.toBe(fb)
-    expect(fa()).toBe(fb())
   })
   test('copies objects (class instances) without losing the class type', () => {
     class Data {

--- a/tests/object/construct.test.ts
+++ b/tests/object/construct.test.ts
@@ -1,11 +1,6 @@
 import * as _ from 'radashi'
 
 describe('construct', () => {
-  test('handles bad input', () => {
-    expect(_.construct({})).toEqual({})
-    expect(_.construct(null as any)).toEqual({})
-    expect(_.construct(undefined as any)).toEqual({})
-  })
   test('returns correctly constructed object', () => {
     const now = new Date()
     const ra = {

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -1,11 +1,6 @@
 import * as _ from 'radashi'
 
 describe('crush', () => {
-  test('handles bad input', () => {
-    expect(_.crush({})).toEqual({})
-    expect(_.crush(null as any)).toEqual({})
-    expect(_.crush(undefined as any)).toEqual({})
-  })
   test('returns correctly crushed object', () => {
     const now = new Date()
     const ra = {

--- a/tests/object/invert.test.ts
+++ b/tests/object/invert.test.ts
@@ -1,18 +1,12 @@
 import * as _ from 'radashi'
 
-const cast = <T = object>(value: any): T => value
-
 describe('invert', () => {
-  const peopleByRole = {
-    admin: 'jay',
-    user: 'fey',
-    guest: 'bray',
-  }
-  test('handles null input', () => {
-    const result = _.invert(cast(null))
-    expect(result).toEqual({})
-  })
   test('correctly maps keys and values', () => {
+    const peopleByRole = {
+      admin: 'jay',
+      user: 'fey',
+      guest: 'bray',
+    }
     const result = _.invert(peopleByRole)
     expect(result.jay).toBe('admin')
     expect(result.fey).toBe('user')

--- a/tests/object/keys.test.ts
+++ b/tests/object/keys.test.ts
@@ -1,11 +1,6 @@
 import * as _ from 'radashi'
 
 describe('keys', () => {
-  test('handles bad input', () => {
-    expect(_.keys({})).toEqual([])
-    expect(_.keys(null as any)).toEqual([])
-    expect(_.keys(undefined as any)).toEqual([])
-  })
   test('returns correct list of keys', () => {
     const ra = {
       name: 'ra',

--- a/tests/object/listify.test.ts
+++ b/tests/object/listify.test.ts
@@ -1,14 +1,6 @@
 import * as _ from 'radashi'
 
 describe('listify', () => {
-  test('handles null input', () => {
-    const result = _.listify(null as any as Record<string, string>, () => 1)
-    expect(result).toEqual([])
-  })
-  test('handles empty object', () => {
-    const result = _.listify({} as Record<string, string>, () => 1)
-    expect(result).toEqual([])
-  })
   test('calls toItem to convert to list', () => {
     type Index = 'one' | 'two'
     const obj: Record<Index, any> = {

--- a/tests/object/mapEntries.test.ts
+++ b/tests/object/mapEntries.test.ts
@@ -1,23 +1,12 @@
 import * as _ from 'radashi'
 
-const cast = <T = object>(value: any): T => value
-
 describe('mapEntries', () => {
-  const peopleByRole = {
-    admin: 'jay',
-    user: 'fey',
-    guest: 'bray',
-  }
-  test('handles null input', () => {
-    const result = _.mapEntries(
-      cast(null),
-      cast<(key: never, value: never) => [string | number | symbol, unknown]>(
-        null,
-      ),
-    )
-    expect(result).toEqual({})
-  })
   test('correctly maps keys and values', () => {
+    const peopleByRole = {
+      admin: 'jay',
+      user: 'fey',
+      guest: 'bray',
+    }
     const result = _.mapEntries(peopleByRole, (key, value) => [
       value,
       key.toUpperCase(),

--- a/tests/object/omit.test.ts
+++ b/tests/object/omit.test.ts
@@ -1,23 +1,13 @@
 import * as _ from 'radashi'
 
-const cast = <T = any>(value: any): T => value
-
 describe('omit', () => {
   const person = {
     name: 'jay',
     age: 20,
     active: true,
   }
-  test('handles null input', () => {
-    const result = _.omit(null, [])
-    expect(result).toEqual({})
-  })
   test('handles empty keys', () => {
     const result = _.omit(person, [])
-    expect(result).toEqual(person)
-  })
-  test('handles null keys', () => {
-    const result = _.omit(person, cast(null))
     expect(result).toEqual(person)
   })
   test('returns object without omitted properties', () => {

--- a/tests/object/set.test.ts
+++ b/tests/object/set.test.ts
@@ -1,14 +1,6 @@
 import * as _ from 'radashi'
 
 describe('set', () => {
-  test('handle bad input', () => {
-    expect(_.set({}, '', {})).toEqual({})
-    expect(_.set({}, null as any, {})).toEqual({})
-    expect(_.set({}, '', null as any)).toEqual({})
-    expect(_.set(null as any, '', {})).toEqual({})
-    expect(_.set(null as any, null as any, null as any)).toEqual({})
-  })
-
   test('set a direct property', () => {
     expect(_.set({ foo: true }, 'foo', false)).toEqual({ foo: false })
     expect(_.set({}, 'foo', 0)).toEqual({ foo: 0 })

--- a/tests/object/set.test.ts
+++ b/tests/object/set.test.ts
@@ -59,4 +59,8 @@ describe('set', () => {
       cards: { '1234value': 2 },
     })
   })
+
+  test('set ignores undefined values', () => {
+    expect(_.set({}, 'foo', undefined)).toEqual({})
+  })
 })

--- a/tests/object/shake.test.ts
+++ b/tests/object/shake.test.ts
@@ -31,8 +31,4 @@ describe('shake', () => {
       r: 'x',
     })
   })
-  test('handles undefined input', () => {
-    const result = _.shake(undefined!)
-    expect(result).toEqual({})
-  })
 })

--- a/tests/string/camel.test.ts
+++ b/tests/string/camel.test.ts
@@ -9,10 +9,6 @@ describe('camel', () => {
     const result = _.camel('hello')
     expect(result).toBe('hello')
   })
-  test('returns empty string for empty input', () => {
-    const result = _.camel(null as any)
-    expect(result).toBe('')
-  })
   test('a word in camel case should remain in camel case', () => {
     const result = _.camel('helloWorld')
     expect(result).toBe('helloWorld')

--- a/tests/string/capitalize.test.ts
+++ b/tests/string/capitalize.test.ts
@@ -1,10 +1,6 @@
 import * as _ from 'radashi'
 
 describe('capitalize', () => {
-  test('handles null', () => {
-    const result = _.capitalize(null as any)
-    expect(result).toBe('')
-  })
   test('converts hello as Hello', () => {
     const result = _.capitalize('hello')
     expect(result).toBe('Hello')

--- a/tests/string/dash.test.ts
+++ b/tests/string/dash.test.ts
@@ -9,10 +9,6 @@ describe('dash', () => {
     const result = _.dash('hello')
     expect(result).toBe('hello')
   })
-  test('returns empty string for empty input', () => {
-    const result = _.dash(null as any)
-    expect(result).toBe('')
-  })
   test('must handle strings that are camelCase', () => {
     const result = _.dash('helloWorld')
     expect(result).toBe('hello-world')

--- a/tests/string/pascal.test.ts
+++ b/tests/string/pascal.test.ts
@@ -9,10 +9,6 @@ describe('pascal', () => {
     const result = _.pascal('hello')
     expect(result).toBe('Hello')
   })
-  test('returns empty string for empty input', () => {
-    const result = _.pascal(null as any)
-    expect(result).toBe('')
-  })
   test('converts camelCase to PascalCase', () => {
     const result = _.pascal('fooBar')
     expect(result).toBe('FooBar')

--- a/tests/string/snake.test.ts
+++ b/tests/string/snake.test.ts
@@ -27,10 +27,6 @@ describe('snake', () => {
     const result = _.snake('hello')
     expect(result).toBe('hello')
   })
-  test('returns empty string for empty input', () => {
-    const result = _.snake(null as any)
-    expect(result).toBe('')
-  })
   test('returns non alphanumerics with _', () => {
     const result = _.snake('Exobase Starter_flash AND-go')
     expect(result).toBe('exobase_starter_flash_and_go')

--- a/tests/string/title.test.ts
+++ b/tests/string/title.test.ts
@@ -10,8 +10,4 @@ describe('title', () => {
       'Query All Items In Database',
     )
   })
-  test('returns empty string for bad input', () => {
-    expect(_.title(null)).toBe('')
-    expect(_.title(undefined)).toBe('')
-  })
 })

--- a/tests/string/trim.test.ts
+++ b/tests/string/trim.test.ts
@@ -1,10 +1,6 @@
 import * as _ from 'radashi'
 
 describe('trim', () => {
-  test('handles bad input', () => {
-    expect(_.trim(null)).toBe('')
-    expect(_.trim(undefined)).toBe('')
-  })
   test('returns input string correctly trimmed', () => {
     expect(_.trim('\n\n\t\nhello\n\t  \n', '\n\t ')).toBe('hello')
     expect(_.trim('hello', 'x')).toBe('hello')
@@ -14,7 +10,6 @@ describe('trim', () => {
     expect(_.trim('//repos////', '/')).toBe('repos')
     expect(_.trim('/repos/:owner/:repo/', '/')).toBe('repos/:owner/:repo')
   })
-
   test('handles when char to trim is special case in regex', () => {
     expect(_.trim('_- hello_- ', '_- ')).toBe('hello')
   })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
This PR removes any implicit handling of null/undefined input values.

*Some notes:*
- `replace` and `replaceOrAppend` still skip an undefined `item` argument
- Many `if (!array.length)` checks were also removed, preferring brevity over performance for those code paths. I'd be fine with reinstating these checks on a case-by-case basis if benchmarks prove a substantial benefit and the frequency of empty arrays being passed is deemed common.

See the linked discussion for the philosophy behind this change.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
https://github.com/orgs/radashi-org/discussions/48

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

As of now, a codemod will **not** be provided. Implicit nullish handling was never actually documented, so I assume most Radash users will not be affected.

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/alphabetical.ts` | 171 | -15 (-8%) |
| M | `src/array/boil.ts` | 68 | -12 (-15%) |
| M | `src/array/counting.ts` | 105 | -5 (-5%) |
| M | `src/array/diff.ts` | 112 | -97 (-46%) |
| M | `src/array/first.ts` | 61 | -1 (-2%) |
| M | `src/array/fork.ts` | 93 | -5 (-5%) |
| M | `src/array/intersects.ts` | 135 | -19 (-12%) |
| M | `src/array/last.ts` | 69 | -1 (-1%) |
| M | `src/array/merge.ts` | 138 | -72 (-34%) |
| M | `src/array/replace.ts` | 146 | -15 (-9%) |
| M | `src/array/replaceOrAppend.ts` | 166 | -27 (-14%) |
| M | `src/array/select.ts` | 131 | -15 (-10%) |
| M | `src/array/selectFirst.ts` | 130 | -13 (-9%) |
| M | `src/array/sort.ts` | 116 | -15 (-11%) |
| M | `src/array/toggle.ts` | 223 | -31 (-12%) |
| M | `src/array/unzip.ts` | 155 | -26 (-14%) |
| M | `src/array/zipToObject.ts` | 188 | -26 (-12%) |
| M | `src/async/map.ts` | 109 | -15 (-12%) |
| M | `src/async/reduce.ts` | 239 | -10 (-4%) |
| M | `src/number/inRange.ts` | 83 | -102 (-55%) |
| M | `src/number/max.ts` | 113 | -12 (-10%) |
| M | `src/number/min.ts` | 113 | -12 (-10%) |
| M | `src/object/assign.ts` | 347 | -26 (-7%) |
| M | `src/object/clone.ts` | 198 | -130 (-40%) |
| M | `src/object/construct.ts` | 537 | -156 (-23%) |
| M | `src/object/crush.ts` | 285 | -5 (-2%) |
| M | `src/object/invert.ts` | 89 | -5 (-5%) |
| M | `src/object/keys.ts` | 382 | -15 (-4%) |
| M | `src/object/listify.ts` | 106 | -39 (-27%) |
| M | `src/object/mapEntries.ts` | 122 | -5 (-4%) |
| M | `src/object/omit.ts` | 97 | -9 (-8%) |
| M | `src/object/pick.ts` | 251 | -15 (-6%) |
| M | `src/object/set.ts` | 465 | -151 (-25%) |
| M | `src/object/shake.ts` | 115 | -5 (-4%) |
| M | `src/string/camel.ts` | 280 | -77 (-22%) |
| M | `src/string/capitalize.ts` | 123 | -29 (-19%) |
| M | `src/string/dash.ts` | 257 | -77 (-23%) |
| M | `src/string/pascal.ts` | 186 | -15 (-7%) |
| M | `src/string/snake.ts` | 346 | -95 (-22%) |
| M | `src/string/title.ts` | 239 | -34 (-12%) |
| M | `src/string/trim.ts` | 135 | -15 (-10%) |

[^1337]: Function size includes the `import` dependencies of the function.



