### PR TITLE
fix(types): improve the `isArray` return type for `unknown` input type

### DIFF
--- a/src/async/all.ts
+++ b/src/async/all.ts
@@ -42,11 +42,11 @@ export async function all<T extends Record<string, Promise<any>>>(
   promises: T,
 ): Promise<{ [K in keyof T]: Awaited<T[K]> }>
 
-export async function all<
-  T extends Record<string, Promise<any>> | Promise<any>[],
->(promises: T) {
+export async function all(
+  promises: Record<string, Promise<any>> | Promise<any>[],
+): Promise<any> {
   const entries = isArray(promises)
-    ? promises.map(p => [null, p] as [null, Promise<any>])
+    ? promises.map(p => [null, p] as const)
     : Object.entries(promises)
 
   const results = await Promise.all(
@@ -63,16 +63,14 @@ export async function all<
   }
 
   if (isArray(promises)) {
-    return results.map(r => r.result) as T extends Promise<any>[]
-      ? PromiseValues<T>
-      : unknown
+    return results.map(r => r.result)
   }
 
   return results.reduce(
     (acc, item) => {
-      acc[item.key as keyof T] = item.result
+      acc[item.key!] = item.result
       return acc
     },
-    {} as { [K in keyof T]: Awaited<T[K]> },
+    {} as Record<string, any>,
   )
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -107,3 +107,5 @@ export * from './typed/isPrimitive.ts'
 export * from './typed/isPromise.ts'
 export * from './typed/isString.ts'
 export * from './typed/isSymbol.ts'
+
+export * from './types'

--- a/src/typed/isArray.ts
+++ b/src/typed/isArray.ts
@@ -1,8 +1,10 @@
+import { ExtractNotAny } from 'radashi'
+
 export const isArray = Array.isArray as <Input>(
   value: Input,
-) => value is readonly any[] extends Extract<Input, readonly any[]>
+) => value is readonly any[] extends ExtractNotAny<Input, readonly any[]>
   ? Extract<Input, readonly any[]>
-  : any[] extends Extract<Input, any[]>
+  : any[] extends ExtractNotAny<Input, any[]>
     ? Extract<Input, any[]>
     : unknown[] extends Input
       ? unknown[]

--- a/src/typed/isArray.ts
+++ b/src/typed/isArray.ts
@@ -1,2 +1,9 @@
-export const isArray: (value: unknown) => value is readonly any[] =
-  Array.isArray
+export const isArray = Array.isArray as <Input>(
+  value: Input,
+) => value is readonly any[] extends Extract<Input, readonly any[]>
+  ? Extract<Input, readonly any[]>
+  : any[] extends Extract<Input, any[]>
+    ? Extract<Input, any[]>
+    : unknown[] extends Input
+      ? unknown[]
+      : never

--- a/src/typed/isArray.ts
+++ b/src/typed/isArray.ts
@@ -1,4 +1,4 @@
-import { ExtractNotAny } from 'radashi'
+import type { ExtractNotAny } from 'radashi'
 
 export const isArray = Array.isArray as <Input>(
   value: Input,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,25 @@
+declare const any: unique symbol
+
+/**
+ * The `Any` class does not exist at runtime. It's used in type
+ * definitions to detect an `any` type.
+ *
+ * ```ts
+ * type IsAny<T> = [T] extends [Any] ? 'is any' : 'is not any'
+ * ```
+ */
+export declare class Any {
+  private any: typeof any
+}
+
+/**
+ * Extracts `T` if `T` is not `any`, otherwise `never`.
+ *
+ * ```ts
+ * type A = ExtractNotAny<any, string>
+ * //   ^? never
+ * type B = ExtractNotAny<string | number, string>
+ * //   ^? string
+ * ```
+ */
+export type ExtractNotAny<T, U> = Extract<[T] extends [Any] ? never : T, U>

--- a/tests/typed/isArray.test-d.ts
+++ b/tests/typed/isArray.test-d.ts
@@ -1,6 +1,14 @@
 import * as _ from 'radashi'
 
 describe('isArray return type', () => {
+  test('value is any', () => {
+    const value = {} as any
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<unknown[]>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<any>()
+    }
+  })
   test('value is unknown', () => {
     const value = {} as unknown
     if (_.isArray(value)) {

--- a/tests/typed/isArray.test-d.ts
+++ b/tests/typed/isArray.test-d.ts
@@ -1,0 +1,44 @@
+import * as _ from 'radashi'
+
+describe('isArray return type', () => {
+  test('value is unknown', () => {
+    const value = {} as unknown
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<unknown[]>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<unknown>()
+    }
+  })
+  test('value is string', () => {
+    const value = {} as string
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<never>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  })
+  test('value is string or ReadonlyMap', () => {
+    const value = {} as string | readonly string[]
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<readonly string[]>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  })
+  test('value is string, ReadonlyMap, or Map', () => {
+    const value = {} as string | readonly string[] | string[]
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<readonly string[] | string[]>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  })
+  test('value is string or Map', () => {
+    const value = {} as string | string[]
+    if (_.isArray(value)) {
+      expectTypeOf(value).toEqualTypeOf<string[]>()
+    } else {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
This PR adds “type tests” for `isArray`, showcasing its utility. See the `tests/typed/isArray.test-d.ts` file. Notably, our `isArray` utility actually works with readonly arrays, while `Array.isArray` does not.

In addition, it improves the return type when the input value is typed `unknown`. It now returns a mutable array type, instead of a readonly one. I believe this new behavior is the most common expectation of how it should work.


## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
