### PR TITLE
fix(toggle): handle falsy input as expected

### DIFF
--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -30,25 +30,15 @@ export function toggle<T>(
     strategy?: 'prepend' | 'append'
   },
 ): T[] {
-  if (!array && !item) {
-    return []
-  }
-  if (!array) {
-    return [item]
-  }
-  if (!item) {
-    return [...array]
-  }
   const matcher = toKey
     ? (x: T, idx: number) => toKey(x, idx) === toKey(item, idx)
     : (x: T) => x === item
+
   const existing = array.find(matcher)
-  if (existing) {
+
+  if (existing !== undefined) {
     return array.filter((x, idx) => !matcher(x, idx))
   }
-  const strategy = options?.strategy ?? 'append'
-  if (strategy === 'append') {
-    return [...array, item]
-  }
-  return [item, ...array]
+
+  return options?.strategy === 'prepend' ? [item, ...array] : [...array, item]
 }

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -30,6 +30,16 @@ export function toggle<T>(
     strategy?: 'prepend' | 'append'
   },
 ): T[] {
+  if (!array && !item) {
+    return []
+  }
+  if (!array) {
+    return [item]
+  }
+  if (!item) {
+    return [...array]
+  }
+
   const matcher = toKey
     ? (x: T, idx: number) => toKey(x, idx) === toKey(item, idx)
     : (x: T) => x === item

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -33,6 +33,9 @@ export function toggle<T>(
   if (!array) {
     return item !== undefined ? [item] : []
   }
+  if (item === undefined) {
+    return [...array]
+  }
 
   const matcher = toKey
     ? (x: T, idx: number) => toKey(x, idx) === toKey(item, idx)

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -30,14 +30,8 @@ export function toggle<T>(
     strategy?: 'prepend' | 'append'
   },
 ): T[] {
-  if (!array && !item) {
-    return []
-  }
   if (!array) {
-    return [item]
-  }
-  if (!item) {
-    return [...array]
+    return item !== undefined ? [item] : []
   }
 
   const matcher = toKey

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -1,6 +1,20 @@
 import * as _ from 'radashi'
 
+const cast = <T = any[]>(value: any): T => value
+
 describe('toggle', () => {
+  test('should handle null input list', () => {
+    const result = _.toggle(cast(null), 'a')
+    expect(result).toEqual(['a'])
+  })
+  test('should handle null input list and null item', () => {
+    const result = _.toggle(cast(null), null)
+    expect(result).toEqual([])
+  })
+  test('should handle null item', () => {
+    const result = _.toggle(['a'], null)
+    expect(result).toEqual(['a'])
+  })
   test('should add item when it does not exist using default matcher', () => {
     const result = _.toggle(['a'], 'b')
     expect(result).toEqual(['a', 'b'])

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -4,8 +4,10 @@ const cast = <T = any[]>(value: any): T => value
 
 describe('toggle', () => {
   test('should handle null input list', () => {
-    const result = _.toggle(cast(null), 'a')
+    let result = _.toggle(cast(null), 'a')
     expect(result).toEqual(['a'])
+    result = _.toggle(cast(null), undefined)
+    expect(result).toEqual([])
   })
   test('should skip undefined item', () => {
     const result = _.toggle(['a'], undefined)

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -1,20 +1,6 @@
 import * as _ from 'radashi'
 
-const cast = <T = any[]>(value: any): T => value
-
 describe('toggle', () => {
-  test('should handle null input list', () => {
-    const result = _.toggle(cast(null), 'a')
-    expect(result).toEqual(['a'])
-  })
-  test('should handle null input list and null item', () => {
-    const result = _.toggle(cast(null), null)
-    expect(result).toEqual([])
-  })
-  test('should handle null item', () => {
-    const result = _.toggle(['a'], null)
-    expect(result).toEqual(['a'])
-  })
   test('should add item when it does not exist using default matcher', () => {
     const result = _.toggle(['a'], 'b')
     expect(result).toEqual(['a', 'b'])
@@ -38,5 +24,12 @@ describe('toggle', () => {
   test('should prepend item when strategy is set', () => {
     const result = _.toggle(['a'], 'b', null, { strategy: 'prepend' })
     expect(result).toEqual(['b', 'a'])
+  })
+  test('should work with falsy values', () => {
+    expect(_.toggle([1, 2], 0)).toEqual([1, 2, 0])
+
+    expect(_.toggle([1, 0, 2], 0)).toEqual([1, 2])
+
+    expect(_.toggle([1, 2], null)).toEqual([1, 2, null])
   })
 })

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -7,12 +7,8 @@ describe('toggle', () => {
     const result = _.toggle(cast(null), 'a')
     expect(result).toEqual(['a'])
   })
-  test('should handle null input list and null item', () => {
-    const result = _.toggle(cast(null), null)
-    expect(result).toEqual([])
-  })
-  test('should handle null item', () => {
-    const result = _.toggle(['a'], null)
+  test('should skip undefined item', () => {
+    const result = _.toggle(['a'], undefined)
     expect(result).toEqual(['a'])
   })
   test('should add item when it does not exist using default matcher', () => {


### PR DESCRIPTION

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary
Previously, toggle didn't work with falsy values in array `toggle([1, 2], 0)`.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?


It could be a breaking change (even if it's clearly bug). I think it should be released together with https://github.com/radashi-org/radashi/pull/70. 
