### PR TITLE
feat: add `parseColor` function

### DIFF
--- a/benchmarks/color/parseColor.bench.ts
+++ b/benchmarks/color/parseColor.bench.ts
@@ -1,0 +1,11 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+describe('parseColor', () => {
+  bench('with HEX color', () => {
+    _.parseColor('#00000000')
+  })
+  bench('with RGB color', () => {
+    _.parseColor('rgb(0, 0, 0)')
+  })
+})

--- a/docs/color/parseColor.mdx
+++ b/docs/color/parseColor.mdx
@@ -1,0 +1,42 @@
+---
+title: parseColor
+description: Parses a color string to an RGB color object.
+---
+
+## Basic Usage
+
+The `parseColor` function is designed to parse a color string into an RGB color object. It supports various color formats including HEX, RGB, and RGBA strings.
+
+### Parsing HEX Color Strings
+
+HEX color strings can be in various formats:
+
+```ts
+import * as _ from 'radashi'
+
+_.parseColor('#FFF')
+// => { red: 1, green: 1, blue: 1, alpha: 1 }
+
+_.parseColor('#FFF0')
+// => { red: 1, green: 1, blue: 1, alpha: 0 }
+
+_.parseColor('#ffffff')
+// => { red: 1, green: 1, blue: 1, alpha: 1 }
+
+_.parseColor('#ffffff00')
+// => { red: 1, green: 1, blue: 1, alpha: 0 }
+```
+
+### Parsing RGB and RGBA Color Strings
+
+RGB and RGBA color strings should specify their values within the range:
+
+```ts
+import * as _ from 'radashi'
+
+_.parseColor('rgb(0,0,0)')
+// => { red: 0, green: 0, blue: 0, alpha: 1 }
+
+_.parseColor('rgba(255, 255, 255, 0.5)')
+// => { red: 1, green: 1, blue: 1, alpha: 0.5 }
+```

--- a/src/color/parseColor.ts
+++ b/src/color/parseColor.ts
@@ -1,0 +1,77 @@
+import { Color } from 'radashi'
+
+const hexColorRegex = /^#?([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i
+const rgbColorRegex = /^(rgba?)\((.*?),(.*?),(.*?)(?:,(.*?))?\)$/
+
+/**
+ * Parses a color string to an RGB color object.
+ *
+ * Supports hex, RGB, and RGBA color strings. Hex strings can have 3,
+ * 4, 6, or 8 digits. RGB and RGBA strings should have 0-255 RGB
+ * values and 0-1 alpha values.
+ *
+ * Unless you provide a default value, this function will throw when
+ * given an invalid or unsupported color string.
+ *
+ * ```ts
+ * parseColor('#fff')
+ * // => { red: 1, green: 1, blue: 1, alpha: 1 }
+ *
+ * parseColor('rgb(0,0,0)')
+ * // => { red: 0, green: 0, blue: 0, alpha: 1 }
+ *
+ * parseColor('rgba(255, 255, 255, 0.5)')
+ * // => { red: 1, green: 1, blue: 1, alpha: 0.5 }
+ * ```
+ */
+export function parseColor(input: string): Color
+export function parseColor<T>(input: string, defaultValue: T): Color | T
+export function parseColor(input: string, defaultValue?: any): Color | any {
+  const hex = hexColorRegex.exec(input)
+  if (hex) {
+    return colorHexToRgb(hex[1])
+  }
+  const rgba = rgbColorRegex.exec(input)
+  if (rgba) {
+    const [, fn, red, green, blue, alpha] = rgba
+    return new Color(
+      +red / 255,
+      +green / 255,
+      +blue / 255,
+      fn === 'rgba' ? +alpha : 1,
+    )
+  }
+  if (defaultValue !== undefined) {
+    return defaultValue
+  }
+  throw new Error('Invalid color string: ' + input)
+}
+
+/**
+ * Converts a hexadecimal color string to an RGB color object.
+ * Supports 3, 4, 6, or 8 digit hex colors. The alpha channel is
+ * optional and defaults to fully opaque.
+ *
+ * ```ts
+ * colorHexToRgb('#fff') // => { r: 1, g: 1, b: 1, a: 1 }
+ * ```
+ */
+function colorHexToRgb(hex: string): Color | null {
+  // Compute slice factor based on whether it's a 3/4 or 6/8 digit hex.
+  const f = hex.length < 6 ? 1 : 2
+
+  // Extract bytes from matching slice.
+  let red = Number.parseInt(hex.slice(0 * f, 1 * f), 16)
+  let green = Number.parseInt(hex.slice(1 * f, 2 * f), 16)
+  let blue = Number.parseInt(hex.slice(2 * f, 3 * f), 16)
+  const alpha = Number.parseInt(hex.slice(3 * f, 4 * f) || 'ff', 16)
+
+  // If it's a 3/4 digit hex, copy the bytes to the left.
+  if (f === 1) {
+    red = red | (red << 4)
+    green = green | (green << 4)
+    blue = blue | (blue << 4)
+  }
+
+  return new Color(red / 255, green / 255, blue / 255, alpha / 255)
+}

--- a/src/color/types.ts
+++ b/src/color/types.ts
@@ -1,0 +1,30 @@
+/**
+ * RGB color model.
+ *
+ * Its values range from 0 to 1.
+ *
+ * Objects of this type are safe to stringify using template literals.
+ *
+ * ```ts
+ * const color = new Color(0.5, 0.5, 0.5)
+ * console.log(`Color: ${color}`)
+ * // Logs “Color: rgba(128, 128, 128, 1)”
+ * ```
+ */
+export class Color {
+  constructor(
+    public red: number,
+    public green: number,
+    public blue: number,
+    public alpha = 1,
+  ) {}
+  /**
+   * Returns a string representation of the color in the format
+   * 'rgba(255, 255, 255, 1)'
+   */
+  toString(): string {
+    return `rgba(${Math.trunc(this.red * 255)}, ${Math.trunc(this.green * 255)}, ${Math.trunc(this.blue * 255)}, ${this.alpha})`
+  }
+}
+
+export type ColorLike = Color | string

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -42,6 +42,8 @@ export * from './async/retry.ts'
 export * from './async/sleep.ts'
 export * from './async/tryit.ts'
 
+export * from './color/parseColor.ts'
+
 export * from './curry/callable.ts'
 export * from './curry/chain.ts'
 export * from './curry/compose.ts'
@@ -108,4 +110,5 @@ export * from './typed/isPromise.ts'
 export * from './typed/isString.ts'
 export * from './typed/isSymbol.ts'
 
+export * from './color/types'
 export * from './types'

--- a/tests/color/parseColor.test.ts
+++ b/tests/color/parseColor.test.ts
@@ -1,0 +1,59 @@
+import * as _ from 'radashi'
+import { Color } from 'radashi'
+
+describe('parseColor', () => {
+  test('parse HEX color strings', () => {
+    expect(_.parseColor('#FFF')).toEqual(new Color(1, 1, 1, 1))
+    expect(_.parseColor('#FFF0')).toEqual(new Color(1, 1, 1, 0))
+    expect(_.parseColor('#ffffff')).toEqual(new Color(1, 1, 1, 1))
+    expect(_.parseColor('#ffffff00')).toEqual(new Color(1, 1, 1, 0))
+    expect(_.parseColor('#000')).toEqual(new Color(0, 0, 0, 1))
+    expect(_.parseColor('#00000080')).toEqual(new Color(0, 0, 0, 0x80 / 255))
+  })
+  test('parse RGB color strings', () => {
+    expect(_.parseColor('rgb(0,0,0)')).toEqual(new Color(0, 0, 0, 1))
+    expect(_.parseColor('rgb(255,255,255)')).toEqual(new Color(1, 1, 1, 1))
+
+    const f128 = 128 / 255
+    expect(_.parseColor('rgb(128, 128, 128)')).toEqual(
+      new Color(f128, f128, f128, 1),
+    )
+  })
+  test('parse RGBA color strings', () => {
+    expect(_.parseColor('rgba(255,255,255,0.5)')).toEqual(
+      new Color(1, 1, 1, 0.5),
+    )
+    expect(_.parseColor('rgba(0, 0, 0, 0)')).toEqual(new Color(0, 0, 0, 0))
+
+    const f128 = 128 / 255
+    expect(_.parseColor('rgba(128, 128, 128, 0.75)')).toEqual(
+      new Color(f128, f128, f128, 0.75),
+    )
+  })
+  test('stringify the Color object', () => {
+    const white = _.parseColor('#fff')
+    expect(`${white}`).toBe('rgba(255, 255, 255, 1)')
+  })
+  test('HSL strings are not supported', () => {
+    expect(() => _.parseColor('hsl(0, 100%, 100%)')).toThrow(
+      'Invalid color string: hsl(0, 100%, 100%)',
+    )
+  })
+  test('out-of-bounds RGB values are not clamped', () => {
+    const f256 = 256 / 255
+    expect(_.parseColor('rgb(256, 256, 256)')).toEqual(
+      new Color(f256, f256, f256, 1),
+    )
+  })
+  test('return the default value for invalid color strings', () => {
+    expect(_.parseColor('not a color', 'default')).toBe('default')
+    expect(_.parseColor('#ff', null)).toBe(null)
+  })
+  test('throw an error for invalid color strings', () => {
+    expect(() => _.parseColor('not a color')).toThrow(
+      'Invalid color string: not a color',
+    )
+    expect(() => _.parseColor('#ggg')).toThrow('Invalid color string: #ggg')
+    expect(() => _.parseColor('#ff')).toThrow('Invalid color string: #ff')
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Introduces the `parseColor` function, which supports HEX strings (e.g. `#fff`) and RGB/RGBA strings (e.g. `rgb(255, 255, 255)`). It returns a `Color` instance with red/green/blue/alpha properties and a `toString` method. This will be used by the upcoming color-mixing functions.

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
