### PR TITLE
feat: add `colorMixCMYK` and `colorMixLAB` functions

### DIFF
--- a/benchmarks/color/parseColor.bench.ts
+++ b/benchmarks/color/parseColor.bench.ts
@@ -1,0 +1,11 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+describe('parseColor', () => {
+  bench('with HEX color', () => {
+    _.parseColor('#00000000')
+  })
+  bench('with RGB color', () => {
+    _.parseColor('rgb(0, 0, 0)')
+  })
+})

--- a/benchmarks/number/lerp.bench.ts
+++ b/benchmarks/number/lerp.bench.ts
@@ -1,0 +1,8 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+describe('lerp', () => {
+  bench('with valid input', () => {
+    _.lerp(0, 10, 0.5)
+  })
+})

--- a/docs/color/parseColor.mdx
+++ b/docs/color/parseColor.mdx
@@ -1,0 +1,42 @@
+---
+title: parseColor
+description: Parses a color string to an RGB color object.
+---
+
+## Basic Usage
+
+The `parseColor` function is designed to parse a color string into an RGB color object. It supports various color formats including HEX, RGB, and RGBA strings.
+
+### Parsing HEX Color Strings
+
+HEX color strings can be in various formats:
+
+```ts
+import * as _ from 'radashi'
+
+_.parseColor('#FFF')
+// => { red: 1, green: 1, blue: 1, alpha: 1 }
+
+_.parseColor('#FFF0')
+// => { red: 1, green: 1, blue: 1, alpha: 0 }
+
+_.parseColor('#ffffff')
+// => { red: 1, green: 1, blue: 1, alpha: 1 }
+
+_.parseColor('#ffffff00')
+// => { red: 1, green: 1, blue: 1, alpha: 0 }
+```
+
+### Parsing RGB and RGBA Color Strings
+
+RGB and RGBA color strings should specify their values within the range:
+
+```ts
+import * as _ from 'radashi'
+
+_.parseColor('rgb(0,0,0)')
+// => { red: 0, green: 0, blue: 0, alpha: 1 }
+
+_.parseColor('rgba(255, 255, 255, 0.5)')
+// => { red: 1, green: 1, blue: 1, alpha: 0.5 }
+```

--- a/docs/number/lerp.mdx
+++ b/docs/number/lerp.mdx
@@ -19,4 +19,4 @@ _.lerp(-10, 10, 0.75) // => 5
 
 The name `lerp` is short for "linear interpolation". It's a term from computer graphics that means "interpolate linearly between two values".
 
-For more information, check out the [Wikipedia article](https://en.wikipedia.org/wiki/Linear_interpolation) on linear interpolation. Even better, read [this article](https://keithmaggio.wordpress.com/2011/02/15/math-magician-lerp-slerp-and-nlerp/) by Keith Muggio.
+For more information, check out the [Wikipedia article](https://en.wikipedia.org/wiki/Linear_interpolation) on linear interpolation.

--- a/docs/number/lerp.mdx
+++ b/docs/number/lerp.mdx
@@ -1,0 +1,22 @@
+---
+title: lerp
+description: Smoothly transitions between two values based on a factor
+---
+
+## Basic usage
+
+The `lerp` function is used to linearly interpolate between two numbers based on a specified amount. This function is particularly useful in animations, graphics, and games for smooth transitions.
+
+```ts
+import * as _ from 'radashi'
+
+_.lerp(0, 10, 0.5) // => 5
+_.lerp(5, 15, 0.2) // => 7
+_.lerp(-10, 10, 0.75) // => 5
+```
+
+## Etymology
+
+The name `lerp` is short for "linear interpolation". It's a term from computer graphics that means "interpolate linearly between two values".
+
+For more information, check out the [Wikipedia article](https://en.wikipedia.org/wiki/Linear_interpolation) on linear interpolation. Even better, read [this article](https://keithmaggio.wordpress.com/2011/02/15/math-magician-lerp-slerp-and-nlerp/) by Keith Muggio.

--- a/src/color/colorMixCMYK.ts
+++ b/src/color/colorMixCMYK.ts
@@ -1,0 +1,76 @@
+import { Color, isString, lerp, parseColor, type ColorLike } from 'radashi'
+
+/**
+ * Mixes two colors according to a given ratio using the CMYK color
+ * model.
+ *
+ * This function first converts the input colors to CMYK before
+ * mixing. CMYK is preferred over RGB for color mixing because:
+ * 1. It better represents how physical pigments mix.
+ * 2. It's less likely to produce muddy or unexpected colors when
+ *    mixing.
+ * 3. It often results in more vibrant and natural-looking color
+ *    blends.
+ *
+ * The mixing process:
+ * 1. Convert input colors to CMYK if they're not already.
+ * 2. Interpolate each CMYK component (Cyan, Magenta, Yellow, Key)
+ *    separately.
+ * 3. Convert the resulting CMYK color back to RGB.
+ *
+ * Note: While this method produces good results for most use cases,
+ * it's not perceptually uniform. For the highest perceptual accuracy,
+ * consider using `colorMixLAB`, though it has a larger bundle size
+ * impact (~70% heavier).
+ *
+ * ```ts
+ * colorMixCMYK('#000', '#fff', 0.5)
+ * // => "#808080" (50% black, 50% white)
+ *
+ * const blue = 'rgb(0, 0, 255)'
+ * const yellow = 'rgb(255, 255, 0)'
+ * colorMixCMYK(blue, yellow, 0.5)
+ * // => "rgb(128, 128, 128)" (50% blue, 50% yellow)
+ * ```
+ */
+export function colorMixCMYK(
+  from: ColorLike | Color.CMYK,
+  to: ColorLike | Color.CMYK,
+  ratio: number,
+): Color {
+  from = isString(from)
+    ? colorRgbToCmyk(parseColor(from))
+    : 'red' in from
+      ? colorRgbToCmyk(from)
+      : from
+
+  to = isString(to)
+    ? colorRgbToCmyk(parseColor(to))
+    : 'red' in to
+      ? colorRgbToCmyk(to)
+      : to
+
+  const key = lerp(from.key, to.key, ratio)
+  return new Color(
+    (1 - lerp(from.cyan, to.cyan, ratio)) * (1 - key),
+    (1 - lerp(from.yellow, to.yellow, ratio)) * (1 - key),
+    (1 - lerp(from.magenta, to.magenta, ratio)) * (1 - key),
+    lerp(from.alpha, to.alpha, ratio),
+  )
+}
+
+function colorRgbToCmyk(input: Color): Color.CMYK {
+  const key = 1 - Math.max(input.red, input.green, input.blue)
+  return {
+    cyan: channelRgbToCmyk(input.red, key),
+    magenta: channelRgbToCmyk(input.green, key),
+    yellow: channelRgbToCmyk(input.blue, key),
+    key,
+    alpha: input.alpha,
+  }
+}
+
+function channelRgbToCmyk(input: number, key: number): number {
+  const channel = (1 - input - key) / (1 - key)
+  return Number.isNaN(channel) ? 0 : channel
+}

--- a/src/color/colorMixLAB.ts
+++ b/src/color/colorMixLAB.ts
@@ -1,0 +1,162 @@
+import { Color, type ColorLike, isString, lerp, parseColor } from 'radashi'
+
+/**
+ * Mixes two colors in the LAB color model. This is more perceptually
+ * accurate than `colorMixCMYK` and it's the same approach used by the
+ * `colord` package (from which this logic was adapted).
+ *
+ * @see https://en.wikipedia.org/wiki/CIELAB_color_model
+ */
+export function colorMixLAB(
+  from: ColorLike | Color.LAB,
+  to: ColorLike | Color.LAB,
+  ratio: number,
+): Color {
+  from = isString(from)
+    ? colorRgbToLab(parseColor(from))
+    : 'red' in from
+      ? colorRgbToLab(from)
+      : from
+
+  to = isString(to)
+    ? colorRgbToLab(parseColor(to))
+    : 'red' in to
+      ? colorRgbToLab(to)
+      : to
+
+  return colorLabToRgb(
+    lerp(from.l, to.l, ratio),
+    lerp(from.a, to.a, ratio),
+    lerp(from.b, to.b, ratio),
+    lerp(from.alpha, to.alpha, ratio),
+  )
+}
+
+/**
+ * Converts an RGB channel to its linear light (un-companded) form.
+ * Linearized RGB values are widely used for color space conversions and contrast calculations
+ *
+ * @source https://github.com/omgovich/colord
+ */
+function linearizeRgbChannel(value: number): number {
+  return value < 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+}
+
+/**
+ * Converts an linear-light sRGB channel back to its gamma corrected form
+ *
+ * @source https://github.com/omgovich/colord
+ */
+function unlinearizeRgbChannel(ratio: number): number {
+  return ratio > 0.0031308 ? 1.055 * ratio ** (1 / 2.4) - 0.055 : 12.92 * ratio
+}
+
+/**
+ * Converts an CIE XYZ color (D50) to RGBA color space (D65)
+ *
+ * @see https://www.w3.org/TR/css-color-4/#color-conversion-code
+ * @source https://github.com/omgovich/colord
+ */
+function colorXyzToRgb(x: number, y: number, z: number, alpha: number): Color {
+  // Bradford chromatic adaptation from D50 to D65
+  x = x * 0.9555766 + y * -0.0230393 + z * 0.0631636
+  y = x * -0.0282895 + y * 1.0099416 + z * 0.0210077
+  z = x * 0.0122982 + y * -0.020483 + z * 1.3299098
+
+  return new Color(
+    unlinearizeRgbChannel(0.032404542 * x - 0.015371385 * y - 0.004985314 * z),
+    unlinearizeRgbChannel(-0.00969266 * x + 0.018760108 * y + 0.00041556 * z),
+    unlinearizeRgbChannel(0.000556434 * x - 0.002040259 * y + 0.010572252 * z),
+    alpha,
+  )
+}
+
+/**
+ * Converts an RGB color (D65) to CIE XYZ (D50)
+ *
+ * @see https://image-engineering.de/library/technotes/958-how-to-convert-between-srgb-and-ciexyz
+ * @source https://github.com/omgovich/colord
+ */
+function colorRgbToXyz({ red, green, blue, alpha }: Color): Color.XYZ {
+  // convert RGB to sRGB
+  red = linearizeRgbChannel(red)
+  green = linearizeRgbChannel(green)
+  blue = linearizeRgbChannel(blue)
+
+  // using sRGB own white (D65 no chromatic adaptation)
+  let x = (red * 0.4124564 + green * 0.3575761 + blue * 0.1804375) * 100
+  let y = (red * 0.2126729 + green * 0.7151522 + blue * 0.072175) * 100
+  let z = (red * 0.0193339 + green * 0.119192 + blue * 0.9503041) * 100
+
+  // Bradford chromatic adaptation from D65 to D50
+  x = x * 1.0478112 + y * 0.0228866 + z * -0.050127
+  y = x * 0.0295424 + y * 0.9904844 + z * -0.0170491
+  z = x * -0.0092345 + y * 0.0150436 + z * 0.7521316
+
+  return { x, y, z, alpha }
+}
+
+/**
+ * Theoretical light source that approximates "warm daylight" and
+ * follows the CIE standard.
+ *
+ * @see https://en.wikipedia.org/wiki/Standard_illuminant
+ * @source https://github.com/omgovich/colord
+ */
+const D50 = {
+  x: 96.422,
+  y: 100,
+  z: 82.521,
+}
+
+/**
+ * Performs RGB → CIEXYZ → LAB color conversion
+ *
+ * @see https://www.w3.org/TR/css-color-4/#color-conversion-code
+ * @source https://github.com/omgovich/colord
+ */
+function colorRgbToLab(input: Color): Color.LAB {
+  // Compute XYZ scaled relative to D50 reference white
+  let { x, y, z, alpha } = colorRgbToXyz(input)
+  x /= D50.x
+  y /= D50.y
+  z /= D50.z
+
+  // Conversion factors from https://en.wikipedia.org/wiki/CIELAB_color_space
+  const e = 216 / 24389
+  const k = 24389 / 27
+
+  x = x > e ? Math.cbrt(x) : (k * x + 16) / 116
+  y = y > e ? Math.cbrt(y) : (k * y + 16) / 116
+  z = z > e ? Math.cbrt(z) : (k * z + 16) / 116
+
+  return {
+    l: 116 * y - 16,
+    a: 500 * (x - y),
+    b: 200 * (y - z),
+    alpha,
+  }
+}
+
+/**
+ * Performs LAB → CIEXYZ → RGB color conversion
+ *
+ * @see https://www.w3.org/TR/css-color-4/#color-conversion-code
+ * @source https://github.com/omgovich/colord
+ */
+function colorLabToRgb(l: number, a: number, b: number, alpha: number): Color {
+  const y = (l + 16) / 116
+  const x = a / 500 + y
+  const z = y - b / 200
+
+  // Conversion factors from https://en.wikipedia.org/wiki/CIELAB_color_space
+  const e = 216 / 24389
+  const k = 24389 / 27
+
+  return colorXyzToRgb(
+    (x ** 3 > e ? x ** 3 : (116 * x - 16) / k) * D50.x,
+    (l > k * e ? ((l + 16) / 116) ** 3 : l / k) * D50.y,
+    (z ** 3 > e ? z ** 3 : (116 * z - 16) / k) * D50.z,
+    alpha,
+  )
+}

--- a/src/color/parseColor.ts
+++ b/src/color/parseColor.ts
@@ -1,0 +1,77 @@
+import { Color } from 'radashi'
+
+const hexColorRegex = /^#?([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i
+const rgbColorRegex = /^(rgba?)\((.*?),(.*?),(.*?)(?:,(.*?))?\)$/
+
+/**
+ * Parses a color string to an RGB color object.
+ *
+ * Supports hex, RGB, and RGBA color strings. Hex strings can have 3,
+ * 4, 6, or 8 digits. RGB and RGBA strings should have 0-255 RGB
+ * values and 0-1 alpha values.
+ *
+ * Unless you provide a default value, this function will throw when
+ * given an invalid or unsupported color string.
+ *
+ * ```ts
+ * parseColor('#fff')
+ * // => { red: 1, green: 1, blue: 1, alpha: 1 }
+ *
+ * parseColor('rgb(0,0,0)')
+ * // => { red: 0, green: 0, blue: 0, alpha: 1 }
+ *
+ * parseColor('rgba(255, 255, 255, 0.5)')
+ * // => { red: 1, green: 1, blue: 1, alpha: 0.5 }
+ * ```
+ */
+export function parseColor(input: string): Color
+export function parseColor<T>(input: string, defaultValue: T): Color | T
+export function parseColor(input: string, defaultValue?: any): Color | any {
+  const hex = hexColorRegex.exec(input)
+  if (hex) {
+    return colorHexToRgb(hex[1])
+  }
+  const rgba = rgbColorRegex.exec(input)
+  if (rgba) {
+    const [, fn, red, green, blue, alpha] = rgba
+    return new Color(
+      +red / 255,
+      +green / 255,
+      +blue / 255,
+      fn === 'rgba' ? +alpha : 1,
+    )
+  }
+  if (defaultValue !== undefined) {
+    return defaultValue
+  }
+  throw new Error('Invalid color string: ' + input)
+}
+
+/**
+ * Converts a hexadecimal color string to an RGB color object.
+ * Supports 3, 4, 6, or 8 digit hex colors. The alpha channel is
+ * optional and defaults to fully opaque.
+ *
+ * ```ts
+ * colorHexToRgb('#fff') // => { r: 1, g: 1, b: 1, a: 1 }
+ * ```
+ */
+function colorHexToRgb(hex: string): Color | null {
+  // Compute slice factor based on whether it's a 3/4 or 6/8 digit hex.
+  const f = hex.length < 6 ? 1 : 2
+
+  // Extract bytes from matching slice.
+  let red = Number.parseInt(hex.slice(0 * f, 1 * f), 16)
+  let green = Number.parseInt(hex.slice(1 * f, 2 * f), 16)
+  let blue = Number.parseInt(hex.slice(2 * f, 3 * f), 16)
+  const alpha = Number.parseInt(hex.slice(3 * f, 4 * f) || 'ff', 16)
+
+  // If it's a 3/4 digit hex, copy the bytes to the left.
+  if (f === 1) {
+    red = red | (red << 4)
+    green = green | (green << 4)
+    blue = blue | (blue << 4)
+  }
+
+  return new Color(red / 255, green / 255, blue / 255, alpha / 255)
+}

--- a/src/color/types.ts
+++ b/src/color/types.ts
@@ -1,0 +1,30 @@
+/**
+ * RGB color model.
+ *
+ * Its values range from 0 to 1.
+ *
+ * Objects of this type are safe to stringify using template literals.
+ *
+ * ```ts
+ * const color = new Color(0.5, 0.5, 0.5)
+ * console.log(`Color: ${color}`)
+ * // Logs “Color: rgba(128, 128, 128, 1)”
+ * ```
+ */
+export class Color {
+  constructor(
+    public red: number,
+    public green: number,
+    public blue: number,
+    public alpha = 1,
+  ) {}
+  /**
+   * Returns a string representation of the color in the format
+   * 'rgba(255, 255, 255, 1)'
+   */
+  toString(): string {
+    return `rgba(${Math.trunc(this.red * 255)}, ${Math.trunc(this.green * 255)}, ${Math.trunc(this.blue * 255)}, ${this.alpha})`
+  }
+}
+
+export type ColorLike = Color | string

--- a/src/color/types.ts
+++ b/src/color/types.ts
@@ -27,4 +27,41 @@ export class Color {
   }
 }
 
+export namespace Color {
+  /**
+   * CMYK color model.
+   *
+   * Its values range from 0 to 1.
+   */
+  export type CMYK = {
+    cyan: number
+    magenta: number
+    yellow: number
+    key: number
+    alpha: number
+  }
+  /**
+   * XYZ color model.
+   *
+   * Its values range from 0 to 1.
+   */
+  export type XYZ = {
+    x: number
+    y: number
+    z: number
+    alpha: number
+  }
+  /**
+   * LAB color model.
+   *
+   * Its values range from 0 to 1.
+   */
+  export type LAB = {
+    l: number
+    a: number
+    b: number
+    alpha: number
+  }
+}
+
 export type ColorLike = Color | string

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -42,6 +42,8 @@ export * from './async/retry.ts'
 export * from './async/sleep.ts'
 export * from './async/tryit.ts'
 
+export * from './color/colorMixCMYK.ts'
+export * from './color/colorMixLAB.ts'
 export * from './color/parseColor.ts'
 
 export * from './curry/callable.ts'
@@ -113,3 +115,4 @@ export * from './typed/isSymbol.ts'
 
 export * from './color/types'
 export * from './types'
+

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -55,6 +55,7 @@ export * from './curry/proxied.ts'
 export * from './curry/throttle.ts'
 
 export * from './number/inRange.ts'
+export * from './number/lerp.ts'
 export * from './number/round.ts'
 export * from './number/toFloat.ts'
 export * from './number/toInt.ts'

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -42,6 +42,8 @@ export * from './async/retry.ts'
 export * from './async/sleep.ts'
 export * from './async/tryit.ts'
 
+export * from './color/parseColor.ts'
+
 export * from './curry/callable.ts'
 export * from './curry/chain.ts'
 export * from './curry/compose.ts'
@@ -108,4 +110,5 @@ export * from './typed/isPromise.ts'
 export * from './typed/isString.ts'
 export * from './typed/isSymbol.ts'
 
+export * from './color/types'
 export * from './types'

--- a/src/number/lerp.ts
+++ b/src/number/lerp.ts
@@ -1,0 +1,12 @@
+/**
+ * Linearly interpolates between two numbers.
+ *
+ * ```
+ * lerp(0, 10, 0.5) // => 5
+ * lerp(5, 15, 0.2) // => 7
+ * lerp(-10, 10, 0.75) // => 5
+ * ```
+ */
+export function lerp(from: number, to: number, amount: number): number {
+  return from + (to - from) * amount
+}

--- a/tests/color/colorMixCMYK.test.ts
+++ b/tests/color/colorMixCMYK.test.ts
@@ -1,0 +1,37 @@
+import * as _ from 'radashi'
+import { Color } from 'radashi'
+
+describe('colorMixCMYK', () => {
+  test('mixes black and white', () => {
+    expect(_.colorMixCMYK('#000000', '#FFFFFF', 0.5)).toEqual(
+      new Color(0.5, 0.5, 0.5, 1),
+    )
+  })
+  test('mixes blue and yellow', () => {
+    expect(_.colorMixCMYK('#0000FF', '#FFFF00', 0.5)).toEqual(
+      new Color(0.5, 0.5, 0.5, 1),
+    )
+  })
+  test('mixes red and green with different ratios', () => {
+    expect(_.colorMixCMYK('#FF0000', '#00FF00', 0.25)).toEqual(
+      new Color(0.75, 0, 0.25, 1),
+    )
+    expect(_.colorMixCMYK('#FF0000', '#00FF00', 0.75)).toEqual(
+      new Color(0.25, 0, 0.75, 1),
+    )
+  })
+  test('handles alpha channel', () => {
+    expect(_.colorMixCMYK('#FF0000', '#00FF0000', 0.5)).toEqual(
+      new Color(0.5, 0, 0.5, 0.5),
+    )
+  })
+  test('mixes CMYK colors', () => {
+    expect(
+      _.colorMixCMYK(
+        { cyan: 0, magenta: 1, yellow: 0.75, key: 0.5, alpha: 1 },
+        { cyan: 1, magenta: 0.5, yellow: 0.25, key: 0, alpha: 1 },
+        0.5,
+      ),
+    ).toEqual(new Color(0.375, 0.375, 0.1875, 1))
+  })
+})

--- a/tests/color/parseColor.test.ts
+++ b/tests/color/parseColor.test.ts
@@ -1,0 +1,59 @@
+import * as _ from 'radashi'
+import { Color } from 'radashi'
+
+describe('parseColor', () => {
+  test('parse HEX color strings', () => {
+    expect(_.parseColor('#FFF')).toEqual(new Color(1, 1, 1, 1))
+    expect(_.parseColor('#FFF0')).toEqual(new Color(1, 1, 1, 0))
+    expect(_.parseColor('#ffffff')).toEqual(new Color(1, 1, 1, 1))
+    expect(_.parseColor('#ffffff00')).toEqual(new Color(1, 1, 1, 0))
+    expect(_.parseColor('#000')).toEqual(new Color(0, 0, 0, 1))
+    expect(_.parseColor('#00000080')).toEqual(new Color(0, 0, 0, 0x80 / 255))
+  })
+  test('parse RGB color strings', () => {
+    expect(_.parseColor('rgb(0,0,0)')).toEqual(new Color(0, 0, 0, 1))
+    expect(_.parseColor('rgb(255,255,255)')).toEqual(new Color(1, 1, 1, 1))
+
+    const f128 = 128 / 255
+    expect(_.parseColor('rgb(128, 128, 128)')).toEqual(
+      new Color(f128, f128, f128, 1),
+    )
+  })
+  test('parse RGBA color strings', () => {
+    expect(_.parseColor('rgba(255,255,255,0.5)')).toEqual(
+      new Color(1, 1, 1, 0.5),
+    )
+    expect(_.parseColor('rgba(0, 0, 0, 0)')).toEqual(new Color(0, 0, 0, 0))
+
+    const f128 = 128 / 255
+    expect(_.parseColor('rgba(128, 128, 128, 0.75)')).toEqual(
+      new Color(f128, f128, f128, 0.75),
+    )
+  })
+  test('stringify the Color object', () => {
+    const white = _.parseColor('#fff')
+    expect(`${white}`).toBe('rgba(255, 255, 255, 1)')
+  })
+  test('HSL strings are not supported', () => {
+    expect(() => _.parseColor('hsl(0, 100%, 100%)')).toThrow(
+      'Invalid color string: hsl(0, 100%, 100%)',
+    )
+  })
+  test('out-of-bounds RGB values are not clamped', () => {
+    const f256 = 256 / 255
+    expect(_.parseColor('rgb(256, 256, 256)')).toEqual(
+      new Color(f256, f256, f256, 1),
+    )
+  })
+  test('return the default value for invalid color strings', () => {
+    expect(_.parseColor('not a color', 'default')).toBe('default')
+    expect(_.parseColor('#ff', null)).toBe(null)
+  })
+  test('throw an error for invalid color strings', () => {
+    expect(() => _.parseColor('not a color')).toThrow(
+      'Invalid color string: not a color',
+    )
+    expect(() => _.parseColor('#ggg')).toThrow('Invalid color string: #ggg')
+    expect(() => _.parseColor('#ff')).toThrow('Invalid color string: #ff')
+  })
+})

--- a/tests/number/lerp.test.ts
+++ b/tests/number/lerp.test.ts
@@ -1,0 +1,22 @@
+import * as _ from 'radashi'
+
+describe('lerp', () => {
+  test('linearly interpolate between two numbers', () => {
+    expect(_.lerp(0, 10, 0.5)).toBe(5)
+    expect(_.lerp(5, 15, 0.2)).toBe(7)
+    expect(_.lerp(-10, 10, 0.75)).toBe(5)
+  })
+  test('edge cases', () => {
+    expect(_.lerp(0, 10, 0)).toBe(0)
+    expect(_.lerp(0, 10, 1)).toBe(10)
+    expect(_.lerp(5, 5, 0.5)).toBe(5)
+  })
+  test('negative numbers', () => {
+    expect(_.lerp(-5, 5, 0.5)).toBe(0)
+    expect(_.lerp(-10, -5, 0.5)).toBe(-7.5)
+  })
+  test('decimal results', () => {
+    expect(_.lerp(0, 1, 0.3)).toBeCloseTo(0.3, 5)
+    expect(_.lerp(1, 2, 0.75)).toBeCloseTo(1.75, 5)
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Introduces two color mixing functions. For a lighter solution, use `colorMixCMYK` at the cost of perceptual uniformity. I've also included `colorMixLAB` (the same color mixing that `colord` uses) for cases where CMYK mixing isn't good enough, but `colorMixLAB` requires ~70% more bytes of code (minified).

This belongs in Radashi because there isn't a lightweight TypeScript solution for CMYK/LAB color mixing currently maintained anywhere. While color mixing is mostly useful in frontend programming, I think #88 can reduce the impact on Node.js packages that would prefer not to bloat their node_modules with it.

Depends on #86 and #87.

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
