### PR TITLE
feat: support iterables in places

### DIFF
--- a/src/array/select.ts
+++ b/src/array/select.ts
@@ -1,3 +1,5 @@
+import { reduceIterable, type ToIterableItem } from 'radashi'
+
 /**
  * Select performs a filter and a mapper inside of a reduce, only
  * iterating the list one time. If condition is omitted, will
@@ -12,32 +14,41 @@
  * // => [9, 16]
  * ```
  */
-export function select<T, U>(
-  array: readonly T[],
-  mapper: (item: T, index: number) => U,
-  condition: (item: T, index: number) => boolean,
+export function select<T extends object, U>(
+  iterable: T,
+  mapper: (item: ToIterableItem<T>, index: number) => U | null | undefined,
 ): U[]
 
-export function select<T, U>(
-  array: readonly T[],
-  mapper: (item: T, index: number) => U | null | undefined,
+export function select<T extends object, U>(
+  iterable: T,
+  mapper: (item: ToIterableItem<T>, index: number) => U,
+  condition?: (item: ToIterableItem<T>, index: number) => boolean,
 ): U[]
 
-export function select<T, U>(
-  array: readonly T[],
-  mapper: (item: T, index: number) => U,
-  condition?: (item: T, index: number) => boolean,
+export function select<T extends object, U>(
+  iterable: T,
+  mapper: (item: ToIterableItem<T>, index: number) => U,
+  condition?: (item: ToIterableItem<T>, index: number) => boolean,
 ): U[] {
-  if (!array) {
+  if (!iterable) {
     return []
   }
-  let mapped: U
-  return array.reduce((acc, item, index) => {
-    if (condition) {
-      condition(item, index) && acc.push(mapper(item, index))
-    } else if ((mapped = mapper(item, index)) != null) {
-      acc.push(mapped)
-    }
-    return acc
-  }, [] as U[])
+  return reduceIterable(
+    iterable,
+    condition
+      ? (acc, item, index) => {
+          if (condition(item, index)) {
+            acc.push(mapper(item, index))
+          }
+          return acc
+        }
+      : (acc, item, index) => {
+          const mapped = mapper(item, index)
+          if (mapped != null) {
+            acc.push(mapped)
+          }
+          return acc
+        },
+    [] as U[],
+  )
 }

--- a/src/array/selectFirst.ts
+++ b/src/array/selectFirst.ts
@@ -1,3 +1,5 @@
+import { searchIterable, type ToIterableItem } from 'radashi'
+
 /**
  * Select performs a find + map operation, short-circuiting on the first
  * element that satisfies the prescribed condition. If condition is omitted,
@@ -12,18 +14,29 @@
  * // => 9
  * ```
  */
-export function selectFirst<T, U>(
-  array: readonly T[],
-  mapper: (item: T, index: number) => U,
-  condition?: (item: T, index: number) => boolean,
+export function selectFirst<T extends object, U>(
+  iterable: T,
+  mapper: (item: ToIterableItem<T>, index: number) => U,
+  condition?: (item: ToIterableItem<T>, index: number) => boolean,
 ): U | undefined {
-  if (!array) {
+  if (!iterable) {
     return undefined
   }
-  let foundIndex = -1
-  const found = array.find((item, index) => {
-    foundIndex = index
-    return condition ? condition(item, index) : mapper(item, index) != null
-  })
-  return found === undefined ? undefined : mapper(found, foundIndex)
+  let found: boolean | undefined
+  let foundValue: U
+  let lastItem: ToIterableItem<T>
+  let lastIndex: number
+  searchIterable(
+    iterable,
+    condition
+      ? (item, index) =>
+          (found = condition((lastItem = item), (lastIndex = index)))
+      : (item, index) =>
+          (found = (foundValue = mapper(item, (lastIndex = index))) != null),
+  )
+  return found
+    ? condition
+      ? mapper(lastItem!, lastIndex!)
+      : foundValue!
+    : undefined
 }

--- a/src/iterable/reduceIterable.ts
+++ b/src/iterable/reduceIterable.ts
@@ -1,0 +1,14 @@
+import { toIterable, type ToIterableItem } from 'radashi'
+
+export function reduceIterable<T extends object, Acc>(
+  iterable: T,
+  reducer: (acc: Acc, value: ToIterableItem<T>, index: number) => Acc,
+  initial: Acc,
+): Acc {
+  let acc = initial
+  let index = 0
+  for (const value of toIterable(iterable)) {
+    acc = reducer(acc, value, index++)
+  }
+  return acc
+}

--- a/src/iterable/searchIterable.ts
+++ b/src/iterable/searchIterable.ts
@@ -1,0 +1,13 @@
+import { toIterable, type ToIterableItem } from 'radashi'
+
+export function searchIterable<T extends object>(
+  iterable: T,
+  match: (item: ToIterableItem<T>, index: number) => boolean,
+): ToIterableItem<T> | undefined {
+  let index = 0
+  for (const item of toIterable(iterable)) {
+    if (match(item, index++)) {
+      return item
+    }
+  }
+}

--- a/src/iterable/toIterable.ts
+++ b/src/iterable/toIterable.ts
@@ -1,0 +1,25 @@
+export type ToIterableItem<Input extends object> = Input extends Iterable<
+  infer Item
+>
+  ? Item
+  : keyof Input extends infer Key
+    ? Key extends string & keyof Input
+      ? [Key, Input[Key]]
+      : never
+    : never
+
+export type ToIterable<Input> = Input extends object
+  ? Input extends Iterable<any>
+    ? Input
+    : Iterable<ToIterableItem<Input>>
+  : never
+
+export function toIterable<Input extends object>(
+  input: Input,
+): ToIterable<Input>
+
+export function toIterable(input: object) {
+  return Symbol.iterator in input
+    ? (input as Iterable<unknown>)
+    : Object.entries(input)
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -53,6 +53,10 @@ export * from './curry/partob.ts'
 export * from './curry/proxied.ts'
 export * from './curry/throttle.ts'
 
+export * from './iterable/reduceIterable.ts'
+export * from './iterable/searchIterable.ts'
+export * from './iterable/toIterable.ts'
+
 export * from './number/inRange.ts'
 export * from './number/round.ts'
 export * from './number/toFloat.ts'


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
- Add `toIterable` function  
  *This returns iterable objects as-is, otherwise returns `Object.entries` result.*
- Add `reduceIterable` function
- Add `searchIterable` function
- Accept any iterable as `select`'s first argument
- Accept any iterable as `selectFirst`'s first argument

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes
No

<!-- If yes, describe the impact and migration path for existing applications. -->
