### PR TITLE
feat: add `ownProperties`, `ownPropertyNames`, `ownPropertyValues`

### DIFF
--- a/docs/iterable/ownProperties.mdx
+++ b/docs/iterable/ownProperties.mdx
@@ -1,0 +1,56 @@
+---
+title: ownProperties
+description: Create a generator of an object's own property names/values
+---
+
+## Basic usage
+
+Iterates over an object's own property names and values in a lazy manner. This is more efficient than `Object.entries` when the `for..of` loop is ended early with `break` or `return`.
+
+- Symbol properties are skipped.
+- Inherited properties are skipped.
+- Non-enumerable properties are skipped.
+
+```ts
+import * as _ from 'radashi'
+
+const data = {
+  a: 1,
+  b: 2,
+}
+
+for (const [name, value] of _.ownProperties(data)) {
+  console.log(name, value)
+}
+```
+
+### Use Cases
+
+This function is best when you need more accurate TypeScript inference than what `Object.entries` provides or when you need to iterate over the object's own properties in a lazy manner for efficiency. It's particularly useful for objects with hundreds or thousands of properties. As seen below, it pairs well with `selectFirst` due to its indeterminate nature.
+
+```ts
+const logEntries = {
+  '2023-07-01T10:15:30Z': 'User login',
+  '2023-07-01T10:16:45Z': 'Profile updated',
+  '2023-07-01T10:17:20Z': 'Item added to cart',
+  // ... potentially hundreds more entries
+}
+
+// This is useful for efficiently finding the next log entry
+// after a given timestamp in a large dataset
+const firstLogAfter = timestamp =>
+  _.selectFirst(
+    _.ownProperties(logEntries),
+    ([name, value]) => value,
+    ([name, value]) => name > timestamp,
+  )
+
+console.log(firstLogAfter('2023-07-01T10:16:00Z'))
+// => 'Profile updated'
+```
+
+### TypeScript Limitations
+
+Note that the return type isn't entirely accurate, since it includes instance methods that won't actually be yielded. TypeScript currently has no way to omit inherited properties.
+
+In addition, non-enumerable properties are not yielded, but TypeScript will say they are. For these reasons, it's recommended to use this only with plain objects being used as maps.

--- a/docs/iterable/ownPropertyNames.mdx
+++ b/docs/iterable/ownPropertyNames.mdx
@@ -1,0 +1,56 @@
+---
+title: ownPropertyNames
+description: Create a generator of an object's own property names
+---
+
+## Basic usage
+
+Iterates over an object's own property names in a lazy manner. This is more efficient than `Object.keys` when the `for..of` loop is ended early with `break` or `return`.
+
+- Symbol properties are skipped.
+- Inherited properties are skipped.
+- Non-enumerable properties are skipped.
+
+```ts
+import * as _ from 'radashi'
+
+const data = {
+  a: 1,
+  b: 2,
+}
+
+for (const name of _.ownPropertyNames(data)) {
+  console.log(name)
+}
+```
+
+### Use Cases
+
+This function is best when you need more accurate TypeScript inference than what `Object.keys` provides or when you need to iterate over the object's own properties in a lazy manner for efficiency. It's particularly useful for objects with hundreds or thousands of properties. As seen below, it pairs well with `selectFirst` due to its indeterminate nature.
+
+```ts
+const logEntries = {
+  '2023-07-01T10:15:30Z': 'User login',
+  '2023-07-01T10:16:45Z': 'Profile updated',
+  '2023-07-01T10:17:20Z': 'Item added to cart',
+  // ... potentially hundreds more entries
+}
+
+// This is useful for efficiently finding the next log entry
+// after a given timestamp in a large dataset
+const firstLogAfter = timestamp =>
+  _.selectFirst(
+    _.ownPropertyNames(logEntries),
+    name => logEntries[name],
+    name => name > timestamp,
+  )
+
+console.log(firstLogAfter('2023-07-01T10:16:00Z'))
+// => 'Profile updated'
+```
+
+### TypeScript Limitations
+
+Note that the return type isn't entirely accurate, since it includes instance methods that won't actually be yielded. TypeScript currently has no way to omit inherited properties.
+
+In addition, non-enumerable properties are not yielded, but TypeScript will say they are. For these reasons, it's recommended to use this only with plain objects being used as maps.

--- a/docs/iterable/ownPropertyValues.mdx
+++ b/docs/iterable/ownPropertyValues.mdx
@@ -1,0 +1,49 @@
+---
+title: ownPropertyValues
+description: Create a generator of an object's own property values
+---
+
+## Basic usage
+
+Iterates over an object's own property values in a lazy manner. This is more efficient than `Object.values` when the `for..of` loop is ended early with `break` or `return`.
+
+- Symbol properties are skipped.
+- Inherited properties are skipped.
+- Non-enumerable properties are skipped.
+
+```ts
+import * as _ from 'radashi'
+
+const data = {
+  a: 1,
+  b: 2,
+}
+
+for (const value of _.ownPropertyValues(data)) {
+  console.log(value)
+}
+```
+
+### Use Cases
+
+This function is best when you need more accurate TypeScript inference than what `Object.values` provides or when you need to iterate over the object's own properties in a lazy manner for efficiency. It's particularly useful for objects with hundreds or thousands of properties. As seen below, it pairs well with `selectFirst` due to its indeterminate nature.
+
+```ts
+const data = {
+  a: 1,
+  b: 2,
+}
+
+_.selectFirst(
+  _.ownPropertyValues(data),
+  value => value,
+  value => value > 1,
+)
+// => 2
+```
+
+### TypeScript Limitations
+
+Note that the return type isn't entirely accurate, since it includes instance methods that won't actually be yielded. TypeScript currently has no way to omit inherited properties.
+
+In addition, non-enumerable properties are not yielded, but TypeScript will say they are. For these reasons, it's recommended to use this only with plain objects being used as maps.

--- a/src/iterable/ownProperties.ts
+++ b/src/iterable/ownProperties.ts
@@ -1,0 +1,39 @@
+/**
+ * Create a generator that yields the names and values of the object's
+ * own properties.
+ *
+ * #### Use Cases
+ * The core value proposition of this function is the TypeScript DX of
+ * `Object.entries` combined with the lazy nature of generators. For
+ * example, it pairs well with `selectFirst` for these reasons.
+ *
+ * #### TypeScript Limitations
+ * Note that the return type isn't entirely accurate, since it
+ * includes instance methods that won't actually be yielded.
+ * TypeScript currently has no way to omit inherited properties. In
+ * addition, non-enumerable properties are not yielded, but TypeScript
+ * will say they are. For these reasons, it's recommended to use this
+ * only with plain objects being used as maps.
+ */
+export function* ownProperties<T extends object>(
+  iterable: T,
+): Generator<OwnProperties<T>, void, undefined> {
+  for (const key in iterable) {
+    if (Object.prototype.hasOwnProperty.call(iterable, key)) {
+      yield [key, iterable[key]] as any
+    }
+  }
+}
+
+/**
+ * In case an object has multiple “indexed access” signatures, give
+ * each key in `keyof T` its own tuple type and combine them into a
+ * union type.
+ */
+type OwnProperties<T extends object> = T extends any
+  ? keyof T extends infer K
+    ? K extends keyof T & (string | number)
+      ? [K extends string ? K : K extends number ? `${K}` : never, T[K]]
+      : never
+    : never
+  : never

--- a/src/iterable/ownPropertyNames.ts
+++ b/src/iterable/ownPropertyNames.ts
@@ -1,0 +1,36 @@
+/**
+ * Create a generator that yields the names of the object's own
+ * properties.
+ *
+ * #### Use Cases
+ * The core value proposition of this function is the TypeScript DX of
+ * `Object.keys` combined with the lazy nature of generators. For
+ * example, it pairs well with `selectFirst` for these reasons.
+ *
+ * #### TypeScript Limitations
+ * Note that the return type isn't entirely accurate, since it
+ * includes instance methods that won't actually be yielded.
+ * TypeScript currently has no way to omit inherited properties. In
+ * addition, non-enumerable properties are not yielded, but TypeScript
+ * will say they are. For these reasons, it's recommended to use this
+ * only with plain objects being used as maps.
+ */
+export function* ownPropertyNames<T extends object>(
+  iterable: T,
+): Generator<PropertyNames<T>, void, undefined> {
+  for (const key in iterable) {
+    if (Object.prototype.hasOwnProperty.call(iterable, key)) {
+      yield key as any
+    }
+  }
+}
+
+type PropertyNames<T extends object> = T extends any
+  ? keyof T extends infer K
+    ? K extends string
+      ? K
+      : K extends number
+        ? `${K}`
+        : never
+    : never
+  : never

--- a/src/iterable/ownPropertyValues.ts
+++ b/src/iterable/ownPropertyValues.ts
@@ -1,0 +1,30 @@
+/**
+ * Create a generator that yields the values of the object's own
+ * properties.
+ *
+ * #### Use Cases
+ * The core value proposition of this function is the TypeScript DX of
+ * `Object.values` combined with the lazy nature of generators. For
+ * example, it pairs well with `selectFirst` for these reasons.
+ *
+ * #### TypeScript Limitations
+ * Note that the return type isn't entirely accurate, since it
+ * includes instance methods that won't actually be yielded.
+ * TypeScript currently has no way to omit inherited properties. In
+ * addition, non-enumerable properties are not yielded, but TypeScript
+ * will say they are. For these reasons, it's recommended to use this
+ * only with plain objects being used as maps.
+ */
+export function* ownPropertyValues<T extends object>(
+  iterable: T,
+): Generator<PropertyValues<T>, void, undefined> {
+  for (const key in iterable) {
+    if (Object.prototype.hasOwnProperty.call(iterable, key)) {
+      yield iterable[key] as any
+    }
+  }
+}
+
+type PropertyValues<T extends object> = T extends any
+  ? T[Extract<keyof T, string | number>]
+  : never

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -53,6 +53,10 @@ export * from './curry/partob.ts'
 export * from './curry/proxied.ts'
 export * from './curry/throttle.ts'
 
+export * from './iterable/ownProperties.ts'
+export * from './iterable/ownPropertyNames.ts'
+export * from './iterable/ownPropertyValues.ts'
+
 export * from './number/inRange.ts'
 export * from './number/round.ts'
 export * from './number/toFloat.ts'

--- a/tests/iterable/ownProperties.test-d.ts
+++ b/tests/iterable/ownProperties.test-d.ts
@@ -1,0 +1,97 @@
+import * as _ from 'radashi'
+
+describe('ownProperties', () => {
+  test('basic record', () => {
+    const data = {} as Record<string | number, string>
+    for (const entry of _.ownProperties(data)) {
+      expectTypeOf(entry).toEqualTypeOf<
+        [string, string] | [`${number}`, string]
+      >()
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, string]>()
+    }
+  })
+  test('multiple index signatures', () => {
+    const data = {} as Record<string, string> & Record<number, number>
+    for (const entry of _.ownProperties(data)) {
+      expectTypeOf(entry).toEqualTypeOf<
+        [string, string] | [`${number}`, number]
+      >()
+
+      // Sadly, this doesn't narrow as of TypeScript 5.5.2
+      if (_.isIntString(entry[0])) {
+        // This is fine, we can't rule out entry[1] as a string
+        expectTypeOf(entry[1]).toEqualTypeOf<number | string>()
+      } else {
+        // This should be "string" only, but oh well
+        expectTypeOf(entry[1]).toEqualTypeOf<number | string>()
+      }
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, string | number]>()
+    }
+  })
+  test('object union', () => {
+    const data = {} as Record<string, string> | Record<number, number>
+    for (const entry of _.ownProperties(data)) {
+      expectTypeOf(entry).toEqualTypeOf<
+        [string, string] | [`${number}`, number]
+      >()
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, any]>()
+    }
+  })
+  test('string union for keys', () => {
+    const data = {} as Record<'a' | 'b', string> & Record<'c', number>
+    for (const entry of _.ownProperties(data)) {
+      expectTypeOf(entry).toEqualTypeOf<
+        ['a', string] | ['b', string] | ['c', number]
+      >()
+
+      // Narrowing works with literal keys!
+      if (entry[0] === 'c') {
+        expectTypeOf(entry[1]).toBeNumber()
+      } else {
+        expectTypeOf(entry[1]).toBeString()
+      }
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, string | number]>()
+    }
+  })
+  test('class methods are sadly included', () => {
+    class TestClass {
+      a = 1
+      b() {}
+    }
+    const data = new TestClass()
+    for (const entry of _.ownProperties(data)) {
+      // This would preferably only be ['a', number]
+      expectTypeOf(entry).toEqualTypeOf<['a', number] | ['b', () => void]>()
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, any]>()
+    }
+  })
+  test('array-like objects', () => {
+    const data: ArrayLike<string> = { length: 0 }
+    for (const entry of _.ownProperties(data)) {
+      // This is more accurate, since the "length" property of
+      // ArrayLike is potentially enumerable.
+      expectTypeOf(entry).toEqualTypeOf<
+        [`${number}`, string] | ['length', number]
+      >()
+    }
+    // ⚠️ Does not work the same with Object.entries
+    for (const entry of Object.entries(data)) {
+      expectTypeOf(entry).toEqualTypeOf<[string, string]>()
+    }
+  })
+})

--- a/tests/iterable/ownProperties.test.ts
+++ b/tests/iterable/ownProperties.test.ts
@@ -1,0 +1,56 @@
+import * as _ from 'radashi'
+
+describe('ownProperties', () => {
+  test('basic functionality', () => {
+    const data = { a: 1, b: 2, c: 3 }
+    const result = Array.from(_.ownProperties(data))
+    expect(result).toEqual([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+  })
+  test('numeric properties are converted to strings', () => {
+    const data = [1, 2, 3]
+    const result = Array.from(_.ownProperties(data))
+    expect(result).toEqual([
+      ['0', 1],
+      ['1', 2],
+      ['2', 3],
+    ])
+  })
+  test('enumerable properties of prototype are skipped', () => {
+    const data = { a: 1, b: 2, __proto__: { c: 3 } }
+    const result = Array.from(_.ownProperties(data))
+    expect(result).toEqual([
+      ['a', 1],
+      ['b', 2],
+    ])
+  })
+  test('non-enumerable properties are skipped', () => {
+    const data = { a: 1, b: 2 }
+    Object.defineProperty(data, 'c', { value: 3, enumerable: false })
+    const result = Array.from(_.ownProperties(data))
+    expect(result).toEqual([
+      ['a', 1],
+      ['b', 2],
+    ])
+  })
+  test('symbol properties are skipped', () => {
+    const symbolKey = Symbol('c')
+    const data = { a: 1, b: 2, [symbolKey]: 3 }
+    const result = Array.from(_.ownProperties(data))
+    expect(result).toEqual([
+      ['a', 1],
+      ['b', 2],
+    ])
+  })
+  test('class methods are skipped', () => {
+    class TestClass {
+      a = 1
+      b() {}
+    }
+    const result = Array.from(_.ownProperties(new TestClass()))
+    expect(result).toEqual([['a', 1]])
+  })
+})

--- a/tests/iterable/ownPropertyNames.test-d.ts
+++ b/tests/iterable/ownPropertyNames.test-d.ts
@@ -1,0 +1,72 @@
+import * as _ from 'radashi'
+
+describe('ownPropertyNames', () => {
+  test('basic record', () => {
+    const data = {} as Record<string | number, string>
+    for (const name of _.ownPropertyNames(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+    // Works the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+  test('multiple index signatures', () => {
+    const data = {} as Record<string, string> & Record<number, number>
+    for (const name of _.ownPropertyNames(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+    // Works the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+  test('object union', () => {
+    const data = {} as Record<string, string> | Record<number, number>
+    for (const name of _.ownPropertyNames(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+    // Works the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+  test('numeric properties are stringified', () => {
+    const data = {} as Record<number, number>
+    for (const name of _.ownPropertyNames(data)) {
+      expectTypeOf(name).toEqualTypeOf<`${number}`>()
+    }
+    // ⚠️ Does not work the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+  test('symbol properties are ignored', () => {
+    const symbolKey = Symbol()
+    class Data {
+      a = 1
+      b = 2;
+      [symbolKey] = ''
+    }
+    const data = new Data()
+    for (const name of _.ownPropertyNames(data)) {
+      expectTypeOf(name).toEqualTypeOf<'a' | 'b'>()
+    }
+    // ⚠️ Does not work the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+  test('array-like objects', () => {
+    const data: ArrayLike<string> = { length: 0 }
+    for (const name of _.ownPropertyNames(data)) {
+      // This is more accurate, since the "length" property of
+      // ArrayLike is potentially enumerable.
+      expectTypeOf(name).toEqualTypeOf<`${number}` | 'length'>()
+    }
+    // ⚠️ Does not work the same with Object.keys
+    for (const name of Object.keys(data)) {
+      expectTypeOf(name).toEqualTypeOf<string>()
+    }
+  })
+})

--- a/tests/iterable/ownPropertyNames.test.ts
+++ b/tests/iterable/ownPropertyNames.test.ts
@@ -1,0 +1,39 @@
+import * as _ from 'radashi'
+
+describe('ownPropertyNames', () => {
+  test('basic functionality', () => {
+    const data = { a: 1, b: 2, c: 3 }
+    const result = Array.from(_.ownPropertyNames(data))
+    expect(result).toEqual(['a', 'b', 'c'])
+  })
+  test('numeric properties are converted to strings', () => {
+    const data = [1, 2, 3]
+    const result = Array.from(_.ownPropertyNames(data))
+    expect(result).toEqual(['0', '1', '2'])
+  })
+  test('enumerable properties of prototype are skipped', () => {
+    const data = { a: 1, b: 2, __proto__: { c: 3 } }
+    const result = Array.from(_.ownPropertyNames(data))
+    expect(result).toEqual(['a', 'b'])
+  })
+  test('non-enumerable properties are skipped', () => {
+    const data = { a: 1, b: 2 }
+    Object.defineProperty(data, 'c', { value: 3, enumerable: false })
+    const result = Array.from(_.ownPropertyNames(data))
+    expect(result).toEqual(['a', 'b'])
+  })
+  test('symbol properties are skipped', () => {
+    const symbolKey = Symbol('c')
+    const data = { a: 1, b: 2, [symbolKey]: 3 }
+    const result = Array.from(_.ownPropertyNames(data))
+    expect(result).toEqual(['a', 'b'])
+  })
+  test('class methods are skipped', () => {
+    class TestClass {
+      a = 1
+      b() {}
+    }
+    const result = Array.from(_.ownPropertyNames(new TestClass()))
+    expect(result).toEqual(['a'])
+  })
+})

--- a/tests/iterable/ownPropertyValues.test-d.ts
+++ b/tests/iterable/ownPropertyValues.test-d.ts
@@ -1,0 +1,61 @@
+import * as _ from 'radashi'
+
+describe('ownPropertyValues', () => {
+  test('basic record', () => {
+    const data = {} as Record<string, string | number>
+    for (const value of _.ownPropertyValues(data)) {
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+    // Works the same with Object.values
+    for (const value of Object.values(data)) {
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+  })
+  test('multiple index signatures', () => {
+    const data = {} as Record<string, string> & Record<number, number>
+    for (const value of _.ownPropertyValues(data)) {
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+    // Works the same with Object.values
+    for (const value of Object.values(data)) {
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+  })
+  test('object union', () => {
+    const data = {} as Record<string, string> | Record<number, number>
+    for (const value of _.ownPropertyValues(data)) {
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+    // ⚠️ Does not work the same with Object.values
+    for (const value of Object.values(data)) {
+      expectTypeOf(value).toEqualTypeOf<any>()
+    }
+  })
+  test('symbol properties are ignored', () => {
+    const symbolKey = Symbol()
+    class Data {
+      a = 1;
+      [symbolKey] = ''
+    }
+    const data = new Data()
+    for (const value of _.ownPropertyValues(data)) {
+      expectTypeOf(value).toEqualTypeOf<number>()
+    }
+    // ⚠️ Does not work the same with Object.values
+    for (const value of Object.values(data)) {
+      expectTypeOf(value).toEqualTypeOf<any>()
+    }
+  })
+  test('array-like objects', () => {
+    const data: ArrayLike<string> = { length: 0 }
+    for (const value of _.ownPropertyValues(data)) {
+      // This is more accurate, since the "length" property of
+      // ArrayLike is potentially enumerable.
+      expectTypeOf(value).toEqualTypeOf<string | number>()
+    }
+    // ⚠️ Does not work the same with Object.values
+    for (const value of Object.values(data)) {
+      expectTypeOf(value).toEqualTypeOf<string>()
+    }
+  })
+})

--- a/tests/iterable/ownPropertyValues.test.ts
+++ b/tests/iterable/ownPropertyValues.test.ts
@@ -1,0 +1,39 @@
+import * as _ from 'radashi'
+
+describe('ownPropertyValues', () => {
+  test('basic functionality', () => {
+    const data = { a: 1, b: 2, c: 3 }
+    const result = Array.from(_.ownPropertyValues(data))
+    expect(result).toEqual([1, 2, 3])
+  })
+  test('numeric properties are converted to strings', () => {
+    const data = [1, 2, 3]
+    const result = Array.from(_.ownPropertyValues(data))
+    expect(result).toEqual([1, 2, 3])
+  })
+  test('enumerable properties of prototype are skipped', () => {
+    const data = { a: 1, b: 2, __proto__: { c: 3 } }
+    const result = Array.from(_.ownPropertyValues(data))
+    expect(result).toEqual([1, 2])
+  })
+  test('non-enumerable properties are skipped', () => {
+    const data = { a: 1, b: 2 }
+    Object.defineProperty(data, 'c', { value: 3, enumerable: false })
+    const result = Array.from(_.ownPropertyValues(data))
+    expect(result).toEqual([1, 2])
+  })
+  test('symbol properties are skipped', () => {
+    const symbolKey = Symbol('c')
+    const data = { a: 1, b: 2, [symbolKey]: 3 }
+    const result = Array.from(_.ownPropertyValues(data))
+    expect(result).toEqual([1, 2])
+  })
+  test('class methods are skipped', () => {
+    class TestClass {
+      a = 1
+      b() {}
+    }
+    const result = Array.from(_.ownPropertyValues(new TestClass()))
+    expect(result).toEqual([1])
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Add 3 functions that mirror the behavior of `Object.entries`, `Object.keys`, and `Object.values` but do it lazily (via generator) and provide better type inference (see the `tests/iterable/*.test-d.ts` files for examples).

No benchmarks added, since these implementations are so straight-forward and therefore very unlikely to be optimized.

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
