### PR TITLE
feat!: rework `debounce` function

### DIFF
--- a/.github/next-major.md
+++ b/.github/next-major.md
@@ -4,4 +4,36 @@ The `####` headline should be short and descriptive of the breaking change. In t
 
 ## Breaking Changes
 
-####
+#### Reworked `debounce` function
+
+- Continue debouncing (in future calls) after `cancel` is called. Previously, `cancel` would disable debouncing, so future calls would be immediate.
+
+  ```ts
+  const func = debounce({ delay: 1000 }, mockFunc)
+
+  func()
+  func.cancel()
+
+  vi.advanceTimersByTime(1001)
+  expect(mockFunc).toHaveBeenCalledTimes(0)
+
+  func()
+
+  vi.advanceTimersByTime(1001)
+  expect(mockFunc).toHaveBeenCalledTimes(1)
+  ```
+
+- Do not have `flush` call the underlying function if no call is pending.
+
+  ```ts
+  const func = debounce({ delay: 1000 }, mockFunc)
+  func.flush()
+  expect(mockFunc).toHaveBeenCalledTimes(0) // Would previously have called the function
+  ```
+
+- Expose a reference to the underlying function with the new `callee` property.
+
+  ```ts
+  const func = debounce({ delay: 1000 }, mockFunc)
+  expect(func.callee).toBe(mockFunc)
+  ```

--- a/docs/curry/debounce.mdx
+++ b/docs/curry/debounce.mdx
@@ -6,25 +6,33 @@ since: 12.1.0
 
 ### Usage
 
-The `debounce` function helps manage frequent function calls efficiently. It requires two inputs: a `delay` time (in milliseconds) and a callback. When you use the function returned by `debounce` (a.k.a. the “debounced function”), it doesn't immediately run your callback. Instead, it waits for the specified `delay`.
-
-If called again during this waiting period, it resets the timer. Your source function only runs after the full `delay` passes without interruption. This is useful for handling rapid events like keystrokes, ensuring your code responds only after a pause in activity.
+Create a new function that delays invoking a callback until after a specified time has elapsed since the last call.
 
 ```ts
 import * as _ from 'radashi'
 
-const processData = (data: string) => {
-  console.log(`Processing data: "${data}"...`)
+// Debounce a search function to avoid making API calls on every keystroke
+const searchAPI = _.debounce({ delay: 300 }, async query => {
+  try {
+    const response = await fetch(`https://api.example.com/search?q=${query}`)
+    const results = await response.json()
+    displayResults(results)
+  } catch (error) {
+    console.error('Search failed:', error)
+  }
+})
+
+// Simulate user typing in a search box
+document.querySelector('#search-input').addEventListener('input', event => {
+  const query = event.target.value
+  searchAPI(query)
+})
+
+function displayResults(results) {
+  // Update UI with search results
+  console.log('Search results:', results)
 }
 const debouncedProcessData = _.debounce({ delay: 100 }, processData)
-
-debouncedProcessData('data1') // Never logs
-debouncedProcessData('data2') // Never logs
-debouncedProcessData('data3') // Processing data: "data3"...
-
-setTimeout(() => {
-  debouncedProcessData('data4') // Processing data: "data4"... (200ms later)
-}, 200)
 ```
 
 ## Options
@@ -34,60 +42,46 @@ setTimeout(() => {
 When the `leading` option is `true`, your callback is invoked immediately the very first time the debounced function is called. After that, the debounced function works as if `leading` was `false`.
 
 ```ts
-const myDebouncedFunc = _.debounce({ delay: 100, leading: true }, x => {
+const debouncedFunc = _.debounce({ delay: 100, leading: true }, x => {
   console.log(x)
 })
 
-myDebouncedFunc(0) // Logs "0" immediately
-myDebouncedFunc(1) // Never logs
-myDebouncedFunc(2) // Logs "2" about 100ms later
+debouncedFunc(0) // Logs "0" immediately
+debouncedFunc(1) // Never logs
+debouncedFunc(2) // Logs "2" about 100ms later
 ```
 
-## Methods
+## Return type
 
-### cancel
+The `DebounceFunction` type is used to represent a debounced function in TypeScript. It has the following properties:
 
-The `cancel` method of the debounced function does two things:
+- `callee`: The underlying function that is debounced.
+- `flush`: A method that forces a debounced call to execute immediately.
+- `cancel`: A method that cancels a debounced function.
 
-1. It cancels any pending invocations of the debounced function.
-2. It permanently disables the debouncing behavior. All future invocations of the debounced function will immediately invoke your callback.
+### Flushing
+
+The `flush` method forces a debounced call to execute immediately. If no call was currently scheduled, this method does nothing. So you're effectively saying “execute the function now, but only if it's scheduled to execute.”
 
 ```ts
-const myDebouncedFunc = _.debounce({ delay: 100 }, x => {
-  console.log(x)
+const debouncedFunc = _.debounce({ delay: 1000 }, () => {
+  console.log('Flushed')
 })
 
-myDebouncedFunc(0) // Never logs
-myDebouncedFunc(1) // Never logs
-myDebouncedFunc.cancel()
-myDebouncedFunc(2) // Logs "2" immediately
+debouncedFunc.flush()
 ```
 
-### flush
+The `flush` method is set to [`noop`](/reference/function/noop) when no pending call is scheduled.
 
-The `flush` method will immediately invoke your callback, regardless of whether the debounced function is currently pending.
+### Cancelling
 
-```ts
-const myDebouncedFunc = _.debounce({ delay: 100 }, x => {
-  console.log(x)
-})
-
-myDebouncedFunc(0) // Logs "0" about 100ms later
-myDebouncedFunc.flush(1) // Logs "1" immediately
-```
-
-### isPending
-
-The `isPending` method returns `true` if there is any pending invocation of the debounced function.
+The `cancel` method can be used to cancel a debounced function. Future calls still get debounced, but the currently pending call is immediately cancelled.
 
 ```ts
-const myDebouncedFunc = _.debounce({ delay: 100 }, x => {
-  console.log(x)
+const debouncedFunc = _.debounce({ delay: 1000 }, () => {
+  console.log('Flushed')
 })
 
-myDebouncedFunc(0) // Logs "0" about 100ms later
-myDebouncedFunc.isPending() // => true
-setTimeout(() => {
-  myDebouncedFunc.isPending() // => false
-}, 100)
+debouncedFunc()
+debouncedFunc.cancel()
 ```

--- a/tests/curry/debounce.test.ts
+++ b/tests/curry/debounce.test.ts
@@ -1,5 +1,5 @@
-import * as _ from 'radashi'
 import type { DebounceFunction } from 'radashi'
+import * as _ from 'radashi'
 
 describe('debounce', () => {
   let func: DebounceFunction<any>
@@ -20,60 +20,51 @@ describe('debounce', () => {
     vi.clearAllMocks()
   })
 
-  test('only executes once when called rapidly', async () => {
+  test('only executes once when called rapidly', () => {
     runFunc3Times()
     expect(mockFunc).toHaveBeenCalledTimes(0)
     vi.advanceTimersByTime(delay + 10)
     expect(mockFunc).toHaveBeenCalledTimes(1)
   })
-
-  test('does not debounce after cancel is called', () => {
+  test('cancel prevents the debounced function from being called', () => {
     runFunc3Times()
     expect(mockFunc).toHaveBeenCalledTimes(0)
     func.cancel()
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(3)
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(6)
-  })
-
-  test('executes the function immediately when the flush method is called', () => {
-    func.flush()
-    expect(mockFunc).toHaveBeenCalledTimes(1)
-  })
-
-  test('continues to debounce after flush is called', async () => {
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(0)
-    func.flush()
-    expect(mockFunc).toHaveBeenCalledTimes(1)
-    func()
-    expect(mockFunc).toHaveBeenCalledTimes(1)
-    vi.advanceTimersByTime(delay + 10)
-    expect(mockFunc).toHaveBeenCalledTimes(2)
-    func.flush()
-    expect(mockFunc).toHaveBeenCalledTimes(3)
-  })
-
-  test('cancels all pending invocations when the cancel method is called', async () => {
-    const results: boolean[] = []
-    func()
-    results.push(func.isPending())
-    results.push(func.isPending())
-    vi.advanceTimersByTime(delay + 10)
-    results.push(func.isPending())
-    func()
-    results.push(func.isPending())
-    vi.advanceTimersByTime(delay + 10)
-    results.push(func.isPending())
-    assert.deepEqual(results, [true, true, false, true, false])
-  })
-
-  test('returns if there is any pending invocation when the pending method is called', async () => {
-    func()
-    func.cancel()
     vi.advanceTimersByTime(delay + 10)
     expect(mockFunc).toHaveBeenCalledTimes(0)
+
+    // Verify that new calls after cancel are debounced normally
+    runFunc3Times()
+    expect(mockFunc).toHaveBeenCalledTimes(0)
+    vi.advanceTimersByTime(delay + 10)
+    expect(mockFunc).toHaveBeenCalledTimes(1)
+  })
+
+  describe('flush', () => {
+    test('only calls the function if the debounced function was called', () => {
+      runFunc3Times()
+      expect(mockFunc).toHaveBeenCalledTimes(0)
+
+      func.flush()
+      expect(mockFunc).toHaveBeenCalledTimes(1)
+      expect(func.isPending()).toBe(false)
+
+      func.flush()
+      expect(mockFunc).toHaveBeenCalledTimes(1)
+      expect(func.isPending()).toBe(false)
+    })
+    test('debouncing resumes after a flush', () => {
+      runFunc3Times()
+      expect(mockFunc).toHaveBeenCalledTimes(0)
+      func.flush()
+      expect(mockFunc).toHaveBeenCalledTimes(1)
+      expect(func.isPending()).toBe(false)
+
+      runFunc3Times()
+      expect(mockFunc).toHaveBeenCalledTimes(1)
+      vi.advanceTimersByTime(delay + 10)
+      expect(mockFunc).toHaveBeenCalledTimes(2)
+    })
   })
 
   test('executes the function immediately on the first invocation when `leading` is `true`', async () => {

--- a/tests/curry/debounce.test.ts
+++ b/tests/curry/debounce.test.ts
@@ -42,23 +42,20 @@ describe('debounce', () => {
 
   describe('flush', () => {
     test('only calls the function if the debounced function was called', () => {
+      expect(func.flush).toBe(_.noop)
+
       runFunc3Times()
       expect(mockFunc).toHaveBeenCalledTimes(0)
 
       func.flush()
       expect(mockFunc).toHaveBeenCalledTimes(1)
-      expect(func.isPending()).toBe(false)
-
-      func.flush()
-      expect(mockFunc).toHaveBeenCalledTimes(1)
-      expect(func.isPending()).toBe(false)
+      expect(func.flush).toBe(_.noop)
     })
     test('debouncing resumes after a flush', () => {
       runFunc3Times()
       expect(mockFunc).toHaveBeenCalledTimes(0)
       func.flush()
       expect(mockFunc).toHaveBeenCalledTimes(1)
-      expect(func.isPending()).toBe(false)
 
       runFunc3Times()
       expect(mockFunc).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
- Continue debouncing (in future calls) after `cancel` is called. Previously, `cancel` would disable debouncing, so future calls would be immediate.
- Do not have `flush` call the underlying function if no call is pending.
- Expose a reference to the underlying function with the new `callee` property.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Resolves #105

Resolves https://github.com/sodiray/radash/issues/362

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/curry/debounce.ts` | 257 | +9 (+4%) |

[^1337]: Function size includes the `import` dependencies of the function.



