### PR TITLE
fix: `debounce` cancel() should clear pending timeout

### DIFF
--- a/docs/curry/debounce.mdx
+++ b/docs/curry/debounce.mdx
@@ -34,7 +34,7 @@ Source Invocations: - - - - - - - - - - x - - - - - - - - - - - - - - - - - x - 
 
 ### Cancel
 
-The function returned by `debounce` has a `cancel` method that when called will permanently stop the source function from being debounced.
+The function returned by `debounce` has a `cancel` method that when called will cancel any pending invocation.
 
 ```ts
 const debounced = _.debounce({ delay: 100 }, api.feed.refresh)

--- a/src/curry/debounce.ts
+++ b/src/curry/debounce.ts
@@ -41,24 +41,20 @@ export function debounce<TArgs extends any[]>(
   func: (...args: TArgs) => any,
 ): DebounceFunction<TArgs> {
   let timer: unknown = undefined
-  let active = true
 
   const debounced: DebounceFunction<TArgs> = (...args: TArgs) => {
-    if (active) {
-      clearTimeout(timer)
-      timer = setTimeout(() => {
-        active && func(...args)
-        timer = undefined
-      }, delay)
-    } else {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
       func(...args)
-    }
+      timer = undefined
+    }, delay)
   }
   debounced.isPending = () => {
     return timer !== undefined
   }
   debounced.cancel = () => {
-    active = false
+    clearTimeout(timer)
+    timer = undefined
   }
   debounced.flush = (...args: TArgs) => func(...args)
 

--- a/tests/curry/debounce.test.ts
+++ b/tests/curry/debounce.test.ts
@@ -27,14 +27,23 @@ describe('debounce', () => {
     expect(mockFunc).toHaveBeenCalledTimes(1)
   })
 
-  test('does not debounce after cancel is called', () => {
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(0)
+  test('does not execute if cancel called before timeout', () => {
+    func()
+    expect(func.isPending()).toBe(true)
     func.cancel()
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(3)
-    runFunc3Times()
-    expect(mockFunc).toHaveBeenCalledTimes(6)
+    expect(func.isPending()).toBe(false)
+    vi.advanceTimersByTime(delay + 10)
+    expect(mockFunc).toHaveBeenCalledTimes(0)
+  })
+
+  test('continues to debounce after cancel is called', () => {
+    func()
+    func.cancel()
+    vi.advanceTimersByTime(delay + 10)
+    expect(mockFunc).toHaveBeenCalledTimes(0)
+    func()
+    vi.advanceTimersByTime(delay + 10)
+    expect(mockFunc).toHaveBeenCalledTimes(1)
   })
 
   test('executes the function immediately when the flush method is called', () => {


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

This PR changes the behavior of a debounced function's `cancel()` method:

BEFORE: Calling `cancel()` preempts any pending invocation and permanently makes all future invocations execute immediately (i.e., not be debounced)
AFTER: Calling `cancel()` cancels/clears any pending invocation. Subsequent invocations are debounced as normal.

## Related issue, if any:

Closes #105 

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [X] Related documentation has been updated, if needed
- [X] Related tests have been added or updated, if needed
- [X] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

@aleclarson sounds like we're considering this a "bug", so not sure we'd do anything other than make a note in release notes? Please advise

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._
