### PR TITLE
feat: add `promiseDebounce` function

### DIFF
--- a/src/curry/promiseDebounce.ts
+++ b/src/curry/promiseDebounce.ts
@@ -1,0 +1,92 @@
+declare const setTimeout: (fn: () => void, ms: number) => unknown
+declare const clearTimeout: (timer: unknown) => void
+
+export type PromiseDebounceFunction<
+  TArgs extends any[] = any,
+  TReturn = any,
+> = {
+  (...args: TArgs): Promise<Awaited<TReturn>>
+  /**
+   * Cancels the debounced function
+   */
+  cancel(): void
+  /**
+   * Checks if there is any invocation debounced
+   */
+  isPending(): boolean
+  /**
+   * If the debounced function is pending, it will be invoked
+   * immediately and the result will be returned. Otherwise,
+   * `undefined` will be returned.
+   */
+  flush(...args: TArgs): TReturn | undefined
+  /**
+   * The underlying function
+   */
+  readonly handler: (...args: TArgs) => TReturn
+}
+
+/**
+ * Same as `debounce`, but a promise is returned that resolves with
+ * the result if that call was the last one.
+ *
+ * - The `cancel` method cancels the debounced function.
+ * - The `flush` method calls the underlying function immediately if
+ *   it was debounced, otherwise it does nothing.
+ * - The `isPending` method checks if the debounced function is
+ *   pending.
+ * - The `toImmediate` method returns the underlying function.
+ *
+ * @see https://radashi-org.github.io/reference/curry/promiseDebounce
+ * @example
+ * ```ts
+ * const myDebouncedFunc = promiseDebounce({ delay: 1000 }, (x) => x + 1)
+ *
+ * myDebouncedFunc(0).then(x => console.log(x))
+ * myDebouncedFunc(1).then(x => console.log(x))
+ * // Logs "2"
+ * ```
+ */
+export function promiseDebounce<TArgs extends any[], TReturn>(
+  { delay }: { delay: number },
+  handler: (...args: TArgs) => TReturn,
+): PromiseDebounceFunction<TArgs, TReturn> {
+  let timeout: unknown | undefined
+  let resolver: ((value: TReturn | PromiseLike<TReturn>) => void) | undefined
+
+  const debounced = ((...args: TArgs) => {
+    return new Promise<TReturn>(resolve => {
+      resolver = resolve
+
+      clearTimeout(timeout)
+      timeout = setTimeout(() => {
+        timeout = undefined
+        resolve(handler(...args))
+      }, delay)
+    })
+  }) as PromiseDebounceFunction<TArgs, TReturn> & { handler: typeof handler }
+
+  debounced.cancel = () => {
+    clearTimeout(timeout)
+    timeout = undefined
+    // The promise's resolver won't be called. JavaScript GC will
+    // clean up every reference to the promise.
+    resolver = undefined
+  }
+
+  debounced.flush = (...args) => {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+      timeout = undefined
+      const oldResolver = resolver
+      const result = handler(...args)
+      oldResolver?.(result)
+      return result
+    }
+  }
+
+  debounced.isPending = () => timeout !== undefined
+  debounced.handler = handler
+
+  return debounced
+}


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
It's like `debounce` but each call returns a promise that doesn't resolve unless that call is the last call before the timeout expires. In other words, only when the call finally succeeds, the returned promise will resolve with the function result.

Basically, if you have a debounced function whose result could be useful, you'll want to use `promiseDebounce` instead.

**Naming is not final. Share your thoughts below!**

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._
