### PR TITLE
fix(assign): fix overriding a nested object with null

### DIFF
--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -25,12 +25,11 @@ export function assign<X extends Record<string | symbol | number, any>>(
   const merged = proto
     ? { ...initial }
     : Object.assign(Object.create(proto), initial)
-  for (const key in override) {
-    if (Object.prototype.hasOwnProperty.call(override, key)) {
-      merged[key] = isPlainObject(initial[key])
+  for (const key of Object.keys(override)) {
+    merged[key] =
+      isPlainObject(initial[key]) && isPlainObject(override[key])
         ? assign(initial[key], override[key])
         : override[key]
-    }
   }
   return merged
 }

--- a/tests/object/assign.test.ts
+++ b/tests/object/assign.test.ts
@@ -49,6 +49,10 @@ describe('assign', () => {
     const result = _.assign({}, { b: 'y' })
     expect(result).toEqual({ b: 'y' })
   })
+  test('handles null overriding nested object', () => {
+    const result = _.assign({ a: { b: { c: 1 } } }, { a: { b: null } })
+    expect(result).toEqual({ a: { b: null } })
+  })
   test('works with Object.create(null)', () => {
     const object = { a: Object.create(null) }
     object.a.b = 1


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Fix `assign` so a nested object can be replaced with null.

See the test case.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
https://github.com/sodiray/radash/issues/373

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/object/assign.ts` | 431 | -23 (-6%) |

