### PR TITLE
feat: use native AggregateError if available

### DIFF
--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -23,7 +23,7 @@ const AggregateErrorOrPolyfill: AggregateErrorConstructor =
       this.stack = errors.find(e => e.stack)?.stack ?? this.stack
       this.errors = errors
     }
-  } as AggregateErrorConstructor)
+  } as unknown as AggregateErrorConstructor)
 
 // Do not export directly, so the polyfill isn't renamed to
 // `AggregateError2` at build time (which ESBuild does to prevent

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -10,8 +10,7 @@ declare const process: { env: any } | undefined
  * environment supported by Radashi (last checked on July 20, 2024).
  * When it's not globally defined, Radashi provides a polyfill.
  *
- * @see
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
  */
 const AggregateErrorOrPolyfill: AggregateErrorConstructor =
   // eslint-disable-next-line compat/compat

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -1,9 +1,12 @@
+/// <reference lib="es2021.promise" />
 /**
  * Support for the built-in AggregateError is still new. Node < 15
  * doesn't have it so patching here.
+ * If AggregateError is available, it will be used; otherwise use
+ * a polyfill
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError#browser_compatibility
  */
-export class AggregateError extends Error {
+class AggregateErrorPolyfill extends Error {
   errors: Error[]
   constructor(errors: Error[] = []) {
     super()
@@ -14,3 +17,6 @@ export class AggregateError extends Error {
     this.errors = errors
   }
 }
+
+export const AggregateError: AggregateErrorConstructor =
+  globalThis.AggregateError ?? AggregateErrorPolyfill

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -1,7 +1,5 @@
 /// <reference lib="es2021.promise" />
 
-declare const process: { env: any } | undefined
-
 /**
  * The `AggregateError` object represents an error when several errors
  * need to be wrapped in a single error.

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -1,22 +1,31 @@
 /// <reference lib="es2021.promise" />
+
+declare const process: { env: any } | undefined
+
 /**
  * Support for the built-in AggregateError is still new. Node < 15
  * doesn't have it so patching here.
- * If AggregateError is available, it will be used; otherwise use
- * a polyfill
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError#browser_compatibility
+ *
+ * If `AggregateError` is globally available, it will be used;
+ * otherwise a polyfill is provided by Radashi.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError#browser_compatibility
  */
-class AggregateErrorPolyfill extends Error {
-  errors: Error[]
-  constructor(errors: Error[] = []) {
-    super()
-    const name = errors.find(e => e.name)?.name ?? ''
-    this.name = `AggregateError(${name}...)`
-    this.message = `AggregateError with ${errors.length} errors`
-    this.stack = errors.find(e => e.stack)?.stack ?? this.stack
-    this.errors = errors
-  }
-}
+const AggregateErrorOrPolyfill: AggregateErrorConstructor =
+  globalThis.AggregateError ??
+  (class AggregateError extends Error {
+    errors: Error[]
+    constructor(errors: Error[] = []) {
+      super()
+      const name = errors.find(e => e.name)?.name ?? ''
+      this.name = `AggregateError(${name}...)`
+      this.message = `AggregateError with ${errors.length} errors`
+      this.stack = errors.find(e => e.stack)?.stack ?? this.stack
+      this.errors = errors
+    }
+  } as AggregateErrorConstructor)
 
-export const AggregateError: AggregateErrorConstructor =
-  globalThis.AggregateError ?? AggregateErrorPolyfill
+// Do not export directly, so the polyfill isn't renamed to
+// `AggregateError2` at build time (which ESBuild does to prevent
+// variable shadowing).
+export { AggregateErrorOrPolyfill as AggregateError }

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -12,6 +12,7 @@ declare const process: { env: any } | undefined
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError#browser_compatibility
  */
 const AggregateErrorOrPolyfill: AggregateErrorConstructor =
+  // eslint-disable-next-line compat/compat
   globalThis.AggregateError ??
   (class AggregateError extends Error {
     errors: Error[]

--- a/src/async/AggregateError.ts
+++ b/src/async/AggregateError.ts
@@ -3,13 +3,15 @@
 declare const process: { env: any } | undefined
 
 /**
- * Support for the built-in AggregateError is still new. Node < 15
- * doesn't have it so patching here.
+ * The `AggregateError` object represents an error when several errors
+ * need to be wrapped in a single error.
  *
- * If `AggregateError` is globally available, it will be used;
- * otherwise a polyfill is provided by Radashi.
+ * As this error type is relatively new, it's not available in every
+ * environment supported by Radashi (last checked on July 20, 2024).
+ * When it's not globally defined, Radashi provides a polyfill.
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError#browser_compatibility
+ * @see
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
  */
 const AggregateErrorOrPolyfill: AggregateErrorConstructor =
   // eslint-disable-next-line compat/compat

--- a/tests/async/AggregateError.test.ts
+++ b/tests/async/AggregateError.test.ts
@@ -1,4 +1,6 @@
-import { AggregateError } from 'radashi'
+import { vi } from 'vitest'
+
+vi.stubGlobal('AggregateError', undefined)
 
 describe('AggregateError error', () => {
   const fakeWork = (name?: string) => {
@@ -18,7 +20,9 @@ describe('AggregateError error', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
-  test('uses stack from the first given error', () => {
+  test.sequential('uses stack from the first given error', async () => {
+    const { AggregateError } = await import('radashi')
+
     const errors: Error[] = []
     try {
       fakeWork()
@@ -29,7 +33,8 @@ describe('AggregateError error', () => {
     expect(aggregate.stack).toContain('at fakeMicrotask')
     expect(aggregate.message).toContain('with 1')
   })
-  test('uses stack from first error with a stack', () => {
+  test('uses stack from first error with a stack', async () => {
+    const { AggregateError } = await import('radashi')
     const errors: Error[] = [{} as Error]
     try {
       fakeWork()
@@ -41,7 +46,8 @@ describe('AggregateError error', () => {
     expect(aggregate.stack).toContain('at fakeMicrotask')
     expect(aggregate.message).toContain('with 2')
   })
-  test('does not fail if no errors given', () => {
+  test('does not fail if no errors given', async () => {
+    const { AggregateError } = await import('radashi')
     new AggregateError([])
     new AggregateError(undefined as unknown as Error[])
   })

--- a/tests/async/AggregateError2.test.ts
+++ b/tests/async/AggregateError2.test.ts
@@ -1,5 +1,0 @@
-test('should use the the native AggregateError if available', async () => {
-  const { AggregateError } = await import('radashi')
-  expect(AggregateError).toBe(globalThis.AggregateError)
-  expect(new AggregateError([])).toBeInstanceOf(globalThis.AggregateError)
-})

--- a/tests/async/AggregateError2.test.ts
+++ b/tests/async/AggregateError2.test.ts
@@ -1,0 +1,5 @@
+test('should use the the native AggregateError if available', async () => {
+  const { AggregateError } = await import('radashi')
+  expect(AggregateError).toBe(globalThis.AggregateError)
+  expect(new AggregateError([])).toBeInstanceOf(globalThis.AggregateError)
+})

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "esnext",
     "lib": ["es2020"],
     "esModuleInterop": true,
+    "module": "ES2020",
     "skipLibCheck": true,
     "strict": true,
     "types": ["vitest/globals"],

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "lib": ["es2020"],
     "esModuleInterop": true,
-    "module": "ES2020",
+    "module": "esnext",
     "skipLibCheck": true,
     "strict": true,
     "types": ["vitest/globals"],


### PR DESCRIPTION
## Summary

Implements logic to use a native implementation if available instead of a polyfill.

## Related issue

#75

## Code changes
- [ ] Related documentation has been updated, if needed.
- [x] Related tests have been added or updated, if needed.
- [ ] Related benchmarks have been added or updated, if needed.

## Question 

To create my test, I had to create a separate file because I encountered issues using `vi.stubGlobal` in the same file. I discovered this happens because Vitest uses the same workers per test file. Running tests simultaneously causes conflicts with `globalThis` sharing. More details can be found in this discussion: https://github.com/vitest-dev/vitest/discussions/1741. The workaround I found was to use two files. It’s not ideal, but it works. Any suggestions for a better solution are welcome.

## Does this PR introduce a breaking change?

No

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._