### PR TITLE
feat(memo)!: add `cache` option

### DIFF
--- a/src/curry/memo.ts
+++ b/src/curry/memo.ts
@@ -1,35 +1,6 @@
-import type { NoInfer } from 'radashi'
-
-type Cache<T> = Record<string, { exp: number | null; value: T }>
-
-function memoize<TArgs extends any[], TResult>(
-  cache: Cache<TResult>,
-  func: (...args: TArgs) => TResult,
-  keyFunc: ((...args: TArgs) => string) | null,
-  ttl: number | null,
-) {
-  return function callWithMemo(...args: any): TResult {
-    const key = keyFunc ? keyFunc(...args) : JSON.stringify({ args })
-    const existing = cache[key]
-    if (existing !== undefined) {
-      if (!existing.exp) {
-        return existing.value
-      }
-      if (existing.exp > new Date().getTime()) {
-        return existing.value
-      }
-    }
-    const result = func(...args)
-    cache[key] = {
-      exp: ttl ? new Date().getTime() + ttl : null,
-      value: result,
-    }
-    return result
-  }
-}
-
-export interface MemoOptions<TArgs extends any[]> {
-  key?: (...args: TArgs) => string
+export interface MemoOptions<TFunc extends (...args: any[]) => any> {
+  cache?: Record<string, { exp: number | null; value: ReturnType<TFunc> }>
+  key?: (...args: Parameters<TFunc>) => string
   ttl?: number
 }
 
@@ -57,9 +28,33 @@ export interface MemoOptions<TArgs extends any[]> {
  * ```
  * @version 12.1.0
  */
-export function memo<TArgs extends any[], TResult>(
-  func: (...args: TArgs) => TResult,
-  options: MemoOptions<NoInfer<TArgs>> = {},
-): (...args: TArgs) => TResult {
-  return memoize({}, func, options.key ?? null, options.ttl ?? null)
+export function memo<TFunc extends (...args: any[]) => any>(
+  func: TFunc,
+  options: MemoOptions<TFunc> = {},
+): Memoized<TFunc> {
+  const { key: keyFunc, ttl, cache = {} } = options
+
+  return function callWithMemo(...args) {
+    const key = keyFunc ? keyFunc(...args) : JSON.stringify({ args })
+    const existing = cache[key]
+    if (existing !== undefined) {
+      if (!existing.exp) {
+        return existing.value
+      }
+      if (existing.exp > new Date().getTime()) {
+        return existing.value
+      }
+    }
+    const result = func(...args)
+    cache[key] = {
+      exp: ttl ? new Date().getTime() + ttl : null,
+      value: result,
+    }
+    return result
+  } as Memoized<TFunc>
 }
+
+export type Memoized<Fn extends (...args: any[]) => any> =
+  ReturnType<Fn> extends infer Result
+    ? (...args: Parameters<Fn>) => Result
+    : never

--- a/src/curry/memo.ts
+++ b/src/curry/memo.ts
@@ -1,5 +1,11 @@
+export type MemoCache<T> = Record<string, { exp: number | null; value: T }>
+
+export type Memoized<TFunc extends (...args: any[]) => any> = (
+  ...args: Parameters<TFunc>
+) => ReturnType<TFunc>
+
 export interface MemoOptions<TFunc extends (...args: any[]) => any> {
-  cache?: Record<string, { exp: number | null; value: ReturnType<TFunc> }>
+  cache?: MemoCache<ReturnType<TFunc>>
   key?: (...args: Parameters<TFunc>) => string
   ttl?: number
 }
@@ -53,8 +59,3 @@ export function memo<TFunc extends (...args: any[]) => any>(
     return result
   } as Memoized<TFunc>
 }
-
-export type Memoized<Fn extends (...args: any[]) => any> =
-  ReturnType<Fn> extends infer Result
-    ? (...args: Parameters<Fn>) => Result
-    : never

--- a/src/curry/memo.ts
+++ b/src/curry/memo.ts
@@ -36,7 +36,7 @@ export interface MemoOptions<TFunc extends (...args: any[]) => any> {
  */
 export function memo<TFunc extends (...args: any[]) => any>(
   func: TFunc,
-  options: MemoOptions<TFunc> = {},
+  options: MemoOptions<NoInfer<TFunc>> = {},
 ): Memoized<TFunc> {
   const { key: keyFunc, ttl, cache = {} } = options
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,13 +47,6 @@ export type SwitchAny<T, U> = [T] extends [Any] ? U : T
 export type SwitchNever<T, U> = [T] extends [never] ? U : T
 
 /**
- * Prevent type inference on type `T`.
- *
- * @see https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546
- */
-export type NoInfer<T> = [T][T extends any ? 0 : never]
-
-/**
  * Extract types in `T` that are assignable to `U`. Coerce `any` and
  * `never` types to unknown.
  */


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
- Expose the `memo` cache as a `cache` option. This allows the memo cache to be managed externally.
- Introduce the `Memoized<T>` type where `T is (...args: any) => any`.
- Remove the internal `memoize` function.

### Breaking Changes

- `memo` only has one type parameter now, and it's a function type
- The `MemoOptions` type only has one type parameter now (same as `memo`)

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/curry/memo.ts` | 278 | -29 (-9%) |

[^1337]: Function size includes the `import` dependencies of the function.



