### PR TITLE
fix(types): let `shift` accept a readonly array type

### DIFF
--- a/src/array/shift.ts
+++ b/src/array/shift.ts
@@ -10,7 +10,7 @@
  * shift([1, 2, 3], -1) // [2, 3, 1]
  * ```
  */
-export function shift<T>(arr: T[], n: number): T[] {
+export function shift<T>(arr: readonly T[], n: number): T[] {
   if (arr.length === 0) {
     return arr
   }


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->

Similar to other changes in radashi, I updated the `shift` function to allow readonly arrays as parameter.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._
