### PR TITLE
feat(throttle): add `trailing` option

### DIFF
--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -1,54 +1,61 @@
 ---
 title: throttle
-description: Create a throttled callback function
+description: Creates a throttled function that limits invocations to a specified interval
 ---
 
 ### Usage
 
-Throttle accepts an options object with an `interval` and a source function to call
-when invoked. Repeated calls to the returned function will only call the source
-function if the `interval` milliseconds of time has passed. Otherwise, it will ignore
-the invocation.
+The `throttle` function creates a new function that, when called, will only execute the original function at most once per specified time interval. This is useful for limiting the rate at which a function can fire, especially for performance-intensive operations like handling scroll or resize events.
 
-```ts
-import * as _ from 'radashi'
+The function accepts two parameters:
 
-const onMouseMove = () => {
-  rerender()
+1. An options object with:
+   - `interval`: The minimum time (in milliseconds) between function invocations
+   - `trailing` (optional): If true, also calls the function after the throttle period if it was invoked during the throttle
+2. The function to be throttled
+
+The returned throttled function also includes an `isThrottled` method to check if there's currently an active throttle.
+
+```typescript
+import { throttle } from 'radashi'
+
+// Throttle a scroll event handler
+const handleScroll = () => {
+  console.log('Scroll position:', window.scrollY)
 }
+const throttledScroll = throttle({ interval: 200 }, handleScroll)
+window.addEventListener('scroll', throttledScroll)
 
-addEventListener('mousemove', _.throttle({ interval: 200 }, onMouseMove))
+// Throttle an API call
+const throttledFetch = throttle(
+  { interval: 5000, trailing: true },
+  async () => {
+    const response = await fetch('https://api.example.com/data')
+    const data = await response.json()
+    console.log(data)
+  },
+)
+
+// Check if throttled
+console.log('Is throttled:', throttledFetch.isThrottled())
 ```
 
-## Timing
+### Timing
 
-A visual of the throttle behavior when `interval` is `200`. The throttle function
-returned by `throttle` can be called every millisecond but it will only call
-the given callback after `interval` milliseconds have passed.
+A visual representation of the throttle behavior when `interval` is set to `200ms`:
 
-```sh
+```
 Time: 0ms - - - - 100ms - - - - 200ms - - - - 300ms - - - - 400ms - - - -
 Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x - - -
 Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
 ```
 
-If the `trailing` option is set to `true`, the source function will be called again after
-`interval` if any invocations were made during the throttled period.
+When the `trailing` option is set to `true`, an additional invocation occurs after the throttle period if any calls were made during the throttled time:
 
-```sh
+```
 Time: 0ms - - - - 100ms - - - - 200ms - - - - 300ms - - - - 400ms - - - -
 Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x - - - - - - - - - - - - -
 Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
 ```
 
-### isThrottled
-
-The function returned by `throttle` has a `isThrottled` method that when called will return if there is any active throttle.
-
-```ts
-const debounced = _.throttle({ interval: 200 }, onMouseMove)
-
-// ... sometime later
-
-debounced.isThrottled()
-```
+In this diagram, 'x' represents function invocations, and '-' represents time passing.

--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -6,7 +6,7 @@ description: Create a throttled callback function
 ### Usage
 
 Throttle accepts an options object with an `interval` and a source function to call
-when invoked. When the returned function is invoked it will only call the source
+when invoked. Repeated calls to the returned function will only call the source
 function if the `interval` milliseconds of time has passed. Otherwise, it will ignore
 the invocation.
 
@@ -29,6 +29,15 @@ the given callback after `interval` milliseconds have passed.
 ```sh
 Time: 0ms - - - - 100ms - - - - 200ms - - - - 300ms - - - - 400ms - - - -
 Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x - - -
+Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
+```
+
+If the `falling` option is set to `true`, the source function will be called again after
+`interval` if any invocations were made during the throttled period.
+
+```sh
+Time: 0ms - - - - 100ms - - - - 200ms - - - - 300ms - - - - 400ms - - - -
+Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x - - - - - - - - - - - - -
 Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
 ```
 

--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -32,7 +32,7 @@ Throttle Invocations: x x x x x x x x x x x x x x x x x x x x x x x x x x x x x 
 Source Invocations: x - - - - - - - - - - - - x - - - - - - - - - - - - - x - - - - - -
 ```
 
-If the `falling` option is set to `true`, the source function will be called again after
+If the `trailing` option is set to `true`, the source function will be called again after
 `interval` if any invocations were made during the throttled period.
 
 ```sh

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -29,9 +29,9 @@ export function throttle<TArgs extends any[]>(
   { interval, trailing = false }: { interval: number; trailing?: boolean },
   func: (...args: TArgs) => any,
 ): ThrottledFunction<TArgs> {
-  let lastCallTime: number | undefined = undefined
-  let timer: ReturnType<typeof setTimeout> | undefined = undefined
-  let lastArgs: TArgs | undefined = undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let lastCallTime: number | undefined
+  let lastArgs: TArgs | undefined
 
   const throttled: ThrottledFunction<TArgs> = (...args: TArgs) => {
     const currentTime = Date.now()

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -26,19 +26,26 @@ export type ThrottledFunction<TArgs extends any[]> = {
  * ```
  */
 export function throttle<TArgs extends any[]>(
-  { interval }: { interval: number },
+  { interval, falling = false }: { interval: number; falling?: boolean },
   func: (...args: TArgs) => any,
 ): ThrottledFunction<TArgs> {
   let ready = true
+  let pending = false
   let timer: unknown = undefined
 
   const throttled: ThrottledFunction<TArgs> = (...args: TArgs) => {
+    pending = true
     if (!ready) {
       return
     }
     func(...args)
     ready = false
+    pending = false
     timer = setTimeout(() => {
+      if (falling && pending) {
+        func(...args)
+        pending = false
+      }
       ready = true
       timer = undefined
     }, interval)

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -44,16 +44,14 @@ export function throttle<TArgs extends any[]>(
       lastArgs = args
     }
 
-    if (timer === undefined) {
-      timer = setTimeout(() => {
-        timer = undefined
-        if (trailing && lastArgs) {
-          func(...lastArgs)
-          lastCallTime = Date.now()
-          lastArgs = undefined
-        }
-      }, interval)
-    }
+    timer ??= setTimeout(() => {
+      timer = undefined
+      if (trailing && lastArgs) {
+        func(...lastArgs)
+        lastCallTime = Date.now()
+        lastArgs = undefined
+      }
+    }, interval)
   }
   throttled.isThrottled = () => {
     return timer !== undefined

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -26,7 +26,7 @@ export type ThrottledFunction<TArgs extends any[]> = {
  * ```
  */
 export function throttle<TArgs extends any[]>(
-  { interval, trailing = false }: { interval: number; trailing?: boolean },
+  { interval, trailing }: { interval: number; trailing?: boolean },
   func: (...args: TArgs) => any,
 ): ThrottledFunction<TArgs> {
   let lastCalled = 0

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -30,31 +30,31 @@ export function throttle<TArgs extends any[]>(
   func: (...args: TArgs) => any,
 ): ThrottledFunction<TArgs> {
   let timer: ReturnType<typeof setTimeout> | undefined
-  let lastCallTime: number | undefined
-  let lastArgs: TArgs | undefined
+  let lastCalled = 0
+  let trailingArgs: TArgs | undefined
 
   const throttled: ThrottledFunction<TArgs> = (...args: TArgs) => {
-    const currentTime = Date.now()
-
-    if (lastCallTime === undefined || currentTime - lastCallTime >= interval) {
+    if (Date.now() - lastCalled >= interval) {
       func(...args)
-      lastCallTime = currentTime
-      lastArgs = undefined
-    } else {
-      lastArgs = args
+      lastCalled = Date.now()
+      trailingArgs = undefined
+    } else if (trailing) {
+      trailingArgs = args
     }
 
     timer ??= setTimeout(() => {
       timer = undefined
-      if (trailing && lastArgs) {
-        func(...lastArgs)
-        lastCallTime = Date.now()
-        lastArgs = undefined
+      if (trailing && trailingArgs) {
+        func(...trailingArgs)
+        lastCalled = Date.now()
+        trailingArgs = undefined
       }
     }, interval)
   }
+
   throttled.isThrottled = () => {
     return timer !== undefined
   }
+
   return throttled
 }

--- a/tests/curry/throttle.test.ts
+++ b/tests/curry/throttle.test.ts
@@ -35,4 +35,24 @@ describe('throttle', () => {
     results.push(func.isThrottled())
     assert.deepEqual(results, [false, true, true, true, false])
   })
+
+  test('single call with falling option is set to `true` calls source function once', async () => {
+    let calls = 0
+    const func = _.throttle({ interval, falling: true }, () => calls++)
+    func()
+    expect(calls).toBe(1)
+    vi.advanceTimersByTime(interval + 10)
+    expect(calls).toBe(1)
+  })
+
+  test('repeated calls with falling option is set to `true` calls source function again on falling edge', async () => {
+    let calls = 0
+    const func = _.throttle({ interval, falling: true }, () => calls++)
+    func()
+    expect(calls).toBe(1)
+    vi.advanceTimersByTime(10)
+    func()
+    vi.advanceTimersByTime(interval + 10)
+    expect(calls).toBe(2)
+  })
 })

--- a/tests/curry/throttle.test.ts
+++ b/tests/curry/throttle.test.ts
@@ -36,48 +36,50 @@ describe('throttle', () => {
     assert.deepEqual(results, [false, true, true, true, false])
   })
 
-  test('single call with trailing option is set to `true` calls source function once', async () => {
-    let calls = 0
-    const func = _.throttle({ interval, trailing: true }, () => calls++)
-    func()
-    expect(calls).toBe(1)
-    vi.advanceTimersByTime(interval + 10)
-    expect(calls).toBe(1)
-  })
+  describe('trailing option', () => {
+    test('single call with trailing option is set to `true` calls source function once', async () => {
+      let calls = 0
+      const func = _.throttle({ interval, trailing: true }, () => calls++)
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(interval + 10)
+      expect(calls).toBe(1)
+    })
 
-  test('repeated calls with trailing option is set to `true` calls source function again on trailing edge', async () => {
-    let calls = 0
-    const func = _.throttle({ interval, trailing: true }, () => calls++)
-    func()
-    expect(calls).toBe(1)
-    vi.advanceTimersByTime(10)
-    func()
-    vi.advanceTimersByTime(interval + 10)
-    expect(calls).toBe(2)
-  })
+    test('repeated calls with trailing option is set to `true` calls source function again on trailing edge', async () => {
+      let calls = 0
+      const func = _.throttle({ interval, trailing: true }, () => calls++)
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(10)
+      func()
+      vi.advanceTimersByTime(interval + 10)
+      expect(calls).toBe(2)
+    })
 
-  test('with trailing option is set to `true`, throttling is still effective after a trailing invocation', async () => {
-    let calls = 0
-    const func = _.throttle({ interval, trailing: true }, () => calls++)
-    func()
-    func()
-    expect(calls).toBe(1)
-    vi.advanceTimersByTime(10)
-    func()
-    func()
-    expect(calls).toBe(1)
-    vi.advanceTimersByTime(interval)
-    // By now, the trailing call should have occurred
-    expect(calls).toBe(2)
+    test('with trailing option is set to `true`, throttling is still effective after a trailing invocation', async () => {
+      let calls = 0
+      const func = _.throttle({ interval, trailing: true }, () => calls++)
+      func()
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(10)
+      func()
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(interval)
+      // By now, the trailing call should have occurred
+      expect(calls).toBe(2)
 
-    vi.advanceTimersByTime(10)
-    func()
-    func()
-    // This call should still be throttled
-    expect(calls).toBe(2)
+      vi.advanceTimersByTime(10)
+      func()
+      func()
+      // This call should still be throttled
+      expect(calls).toBe(2)
 
-    vi.advanceTimersByTime(interval + 10)
-    // By now another trailing call should have happened
-    expect(calls).toBe(3)
+      vi.advanceTimersByTime(interval + 10)
+      // By now another trailing call should have happened
+      expect(calls).toBe(3)
+    })
   })
 })

--- a/tests/curry/throttle.test.ts
+++ b/tests/curry/throttle.test.ts
@@ -36,23 +36,48 @@ describe('throttle', () => {
     assert.deepEqual(results, [false, true, true, true, false])
   })
 
-  test('single call with falling option is set to `true` calls source function once', async () => {
+  test('single call with trailing option is set to `true` calls source function once', async () => {
     let calls = 0
-    const func = _.throttle({ interval, falling: true }, () => calls++)
+    const func = _.throttle({ interval, trailing: true }, () => calls++)
     func()
     expect(calls).toBe(1)
     vi.advanceTimersByTime(interval + 10)
     expect(calls).toBe(1)
   })
 
-  test('repeated calls with falling option is set to `true` calls source function again on falling edge', async () => {
+  test('repeated calls with trailing option is set to `true` calls source function again on trailing edge', async () => {
     let calls = 0
-    const func = _.throttle({ interval, falling: true }, () => calls++)
+    const func = _.throttle({ interval, trailing: true }, () => calls++)
     func()
     expect(calls).toBe(1)
     vi.advanceTimersByTime(10)
     func()
     vi.advanceTimersByTime(interval + 10)
     expect(calls).toBe(2)
+  })
+
+  test('with trailing option is set to `true`, throttling is still effective after a trailing invocation', async () => {
+    let calls = 0
+    const func = _.throttle({ interval, trailing: true }, () => calls++)
+    func()
+    func()
+    expect(calls).toBe(1)
+    vi.advanceTimersByTime(10)
+    func()
+    func()
+    expect(calls).toBe(1)
+    vi.advanceTimersByTime(interval)
+    // By now, the trailing call should have occurred
+    expect(calls).toBe(2)
+
+    vi.advanceTimersByTime(10)
+    func()
+    func()
+    // This call should still be throttled
+    expect(calls).toBe(2)
+
+    vi.advanceTimersByTime(interval + 10)
+    // By now another trailing call should have happened
+    expect(calls).toBe(3)
   })
 })


### PR DESCRIPTION
> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

This adds a `trailing` option for `throttle`, which results in the source function being invoked again after `interval` in case any calls were ignored during the throttled period.

This is useful for situations where an observable is frequently changing, and we wish to throttle an observer without missing any updates. 

## Related issue, if any:

https://github.com/sodiray/radash/pull/387

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No
