### PR TITLE
Refine/tryit - added either/left/right types and type guards

### DIFF
--- a/src/async/tryit.ts
+++ b/src/async/tryit.ts
@@ -1,46 +1,86 @@
-import { isPromise } from 'radashi'
+import { isArray, isPromise } from 'radashi'
 
-/**
- * The result of a `tryit` function.
- *
- * If the function returns a promise, the result is a promise that
- * resolves to an error-first callback-_like_ array response as
- * `[Error, result]`.
- *
- * If the function returns a non-promise, the result is an error-first
- * callback-_like_ array response as `[Error, result]`.
- *
- * @see https://radashi-org.github.io/reference/async/tryit
- * @example
- * ```ts
- * const [err, result] = await tryit(async () => {
- *   return await fetch('https://example.com')
- * })
- * ```
- */
-export type TryitResult<Return> = Return extends Promise<any>
-  ? Promise<[Error, undefined] | [undefined, Awaited<Return>]>
-  : [Error, undefined] | [undefined, Return]
+/** Error type */
+export type Left<E = Error> = [E, undefined]
+
+/** Succeeded type */
+export type Right<T = unknown> = [undefined, T]
+
+/** Either errored (left) or succeeded (right) type */
+export type Either<T = unknown, E = Error> = Left<E> | Right<T>
+
+/** Task = async Either */
+export type Task<T = unknown, E = Error> = Promise<Either<T, E>>
+
+/** syncEither or async Task */
+export type TaskOrEither<T, E> = T extends Promise<infer R>
+  ? Task<R, E>
+  : Either<T, E>
+
+export const isEither = (either: any): either is Either => {
+  return (
+    !isPromise(either) &&
+    isArray(either) &&
+    either.length === 2 &&
+    (either[0] instanceof Error || either[0] === undefined)
+  )
+}
+
+/** returns `true` it the result is an error */
+export const isLeft = <T = unknown, E = Error>(
+  either: Either<T, E>,
+): either is Left<E> => isEither(either) && either[0] !== undefined
+
+/** returns `true` it the result is NOT an error */
+export const isRight = <T = unknown, E = Error>(
+  either: Either<T, E>,
+): either is Right<T> => isEither(either) && either[0] === undefined
+
+/** returns the error component of the either */
+export const left = <T = unknown, E = Error>(either: Either<T, E>): E =>
+  either[0] as E
+
+/** returns the result component of the either */
+export const right = <T = unknown, E = Error>(either: Either<T, E>): T =>
+  either[1] as T
+
+/** Create an errored result */
+export const createLeft = <E extends Error>(error: E): Left<Error> => [
+  error,
+  undefined,
+]
+
+/** Create an succeeded result */
+export const createRight = <T = unknown>(result: T): Right<T> => [
+  undefined,
+  result,
+]
 
 /**
  * A helper to try an async function without forking the control flow.
  * Returns an error-first callback-_like_ array response as `[Error,
  * result]`
  */
-export function tryit<Args extends any[], Return>(
-  func: (...args: Args) => Return,
-): (...args: Args) => TryitResult<Return> {
-  return (...args) => {
+export const tryit = <T, Args extends any[] = unknown[], E = Error>(
+  func: (...args: Args) => T,
+): ((...args: Args) => TaskOrEither<T, E>) => {
+  return (...args: Args): TaskOrEither<T, E> => {
     try {
       const result = func(...args)
       if (isPromise(result)) {
         return result
-          .then(value => [undefined, value])
-          .catch(err => [err, undefined]) as TryitResult<Return>
+          .then(value => createRight(value))
+          .catch(err =>
+            createLeft(
+              err instanceof Error ? err : new Error(JSON.stringify(err)),
+            ),
+          ) as TaskOrEither<T, E>
       }
-      return [undefined, result] as TryitResult<Return>
+      return createRight(result) as TaskOrEither<T, E>
     } catch (err) {
-      return [err, undefined] as TryitResult<Return>
+      return createLeft(
+        err instanceof Error ? err : new Error(JSON.stringify(err)),
+      ) as TaskOrEither<T, E>
     }
   }
 }

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -21,19 +21,20 @@ type Primitive =
 	| undefined
 	| null;
 
+const crushToPvArray: (
+	obj: object,
+	path: string,
+) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
+	Object.entries(obj).flatMap(([key, value]) =>
+		isPrimitive(value) || isDate(value)
+			? { p: path === "" ? key : `${path}.${key}`, v: value }
+			: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
+	);
+
 export function crush<TValue extends object>(
 	value: TValue,
 ): Record<string, Primitive> | Record<string, never> {
 	if (!value) return {};
-	const crushToPvArray: (
-		obj: object,
-		path: string,
-	) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-		Object.entries(obj).flatMap(([key, value]) =>
-			isPrimitive(value) || isDate(value)
-				? { p: path === "" ? key : `${path}.${key}`, v: value }
-				: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
-		);
 
 	const result = objectify(
 		crushToPvArray(value, ""),

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -13,7 +13,7 @@ import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
  */
 export function crush<T extends object>(value: T): Crush<T> {
   if (!value) {
-    return {}
+    return {} as Crush<T>
   }
   return (function crushReducer(
     crushed: Crush<T>,

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,4 @@
-import { isDate, isPrimitive, objectify } from "radashi";
+import { isDate, isPrimitive, objectify } from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -12,34 +12,36 @@ import { isDate, isPrimitive, objectify } from "radashi";
  * ```
  */
 type Primitive =
-	| number
-	| string
-	| boolean
-	| Date
-	| symbol
-	| bigint
-	| undefined
-	| null;
+  | number
+  | string
+  | boolean
+  | Date
+  | symbol
+  | bigint
+  | undefined
+  | null
 
 const crushToPvArray: (
-	obj: object,
-	path: string,
+  obj: object,
+  path: string,
 ) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-	Object.entries(obj).flatMap(([key, value]) =>
-		isPrimitive(value) || isDate(value)
-			? { p: path === "" ? key : `${path}.${key}`, v: value }
-			: crushToPvArray(value, path === "" ? key : `${path}.${key}`),
-	);
+  Object.entries(obj).flatMap(([key, value]) =>
+    isPrimitive(value) || isDate(value)
+      ? { p: path === '' ? key : `${path}.${key}`, v: value }
+      : crushToPvArray(value, path === '' ? key : `${path}.${key}`),
+  )
 
 export function crush<TValue extends object>(
-	value: TValue,
+  value: TValue,
 ): Record<string, Primitive> | Record<string, never> {
-	if (!value) return {};
+  if (!value) {
+    return {}
+  }
 
-	const result = objectify(
-		crushToPvArray(value, ""),
-		(o) => o.p,
-		(o) => o.v,
-	);
-	return result;
+  const result = objectify(
+    crushToPvArray(value, ''),
+    o => o.p,
+    o => o.v,
+  )
+  return result
 }

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,4 @@
-import { isDate, isPrimitive, objectify } from 'radashi'
+import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -11,37 +11,54 @@ import { isDate, isPrimitive, objectify } from 'radashi'
  * // { name: 'ra', 'children.0.name': 'hathor' }
  * ```
  */
-type Primitive =
-  | number
-  | string
-  | boolean
-  | Date
-  | symbol
-  | bigint
-  | undefined
-  | null
-
-const crushToPvArray: (
-  obj: object,
-  path: string,
-) => Array<{ p: string; v: Primitive }> = (obj: object, path: string) =>
-  Object.entries(obj).flatMap(([key, value]) =>
-    isPrimitive(value) || isDate(value)
-      ? { p: path === '' ? key : `${path}.${key}`, v: value }
-      : crushToPvArray(value, path === '' ? key : `${path}.${key}`),
-  )
-
-export function crush<TValue extends object>(
-  value: TValue,
-): Record<string, Primitive> | Record<string, never> {
+export function crush<T extends object>(value: T): Crush<T> {
   if (!value) {
     return {}
   }
-
-  const result = objectify(
-    crushToPvArray(value, ''),
-    o => o.p,
-    o => o.v,
-  )
-  return result
+  return (function crushReducer(
+    crushed: Crush<T>,
+    value: unknown,
+    path: string,
+  ) {
+    if (isObject(value) || isArray(value)) {
+      for (const [prop, propValue] of Object.entries(value)) {
+        crushReducer(crushed, propValue, path ? `${path}.${prop}` : prop)
+      }
+    } else {
+      crushed[path as keyof Crush<T>] = value as Crush<T>[keyof Crush<T>]
+    }
+    return crushed
+  })({} as Crush<T>, value, '')
 }
+
+/**
+ * The return type of the `crush` function.
+ *
+ * This type is limited by TypeScript's development. There's no
+ * reliable way to detect if an object will pass `isObject` or not, so
+ * we cannot infer the property types of nested objects that have been
+ * crushed.
+ *
+ * @see https://radashi-org.github.io/reference/object/crush
+ */
+export type Crush<T> = T extends readonly (infer U)[]
+  ? Record<string, U extends object ? unknown : U>
+  : Simplify<
+      Intersect<
+        keyof T extends infer Prop
+          ? Prop extends keyof T
+            ? T[Prop] extends infer Value
+              ?
+                  | ([Extract<Value, object>] extends [never]
+                      ? never
+                      : Record<string, unknown>)
+                  | ([Exclude<Value, object>] extends [never]
+                      ? never
+                      : [Extract<Value, object>] extends [never]
+                        ? { [P in Prop]: Value }
+                        : Record<string, unknown>)
+              : never
+            : never
+          : never
+      >
+    >

--- a/src/typed/isPromise.ts
+++ b/src/typed/isPromise.ts
@@ -11,6 +11,15 @@ import { isFunction } from 'radashi'
  * isPromise(1) // => false
  * ```
  */
-export function isPromise(value: any): value is Promise<any> {
-  return !!value && isFunction(value.then)
+export function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  if (!value) {
+    return false
+  }
+  if (!(value as any).then) {
+    return false
+  }
+  if (!isFunction((value as any).then)) {
+    return false
+  }
+  return true
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,3 +108,19 @@ export type ComparableProperty<T> = CompatibleProperty<T, Comparable>
  * value, and 0 to keep the order of the values.
  */
 export type Comparator<T> = (left: T, right: T) => number
+
+/** Convert a union to an intersection */
+export type Intersect<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
+
+/**
+ * Useful to flatten the type output to improve type hints shown in
+ * editors. And also to transform an interface into a type to aide
+ * with assignability.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/15300
+ */
+export type Simplify<T> = {} & { [P in keyof T]: T[P] }

--- a/tests/async/retry.test.ts
+++ b/tests/async/retry.test.ts
@@ -1,5 +1,5 @@
-import * as _ from 'radashi'
 import type { RetryOptions } from 'radashi'
+import * as _ from 'radashi'
 
 const cast = <T = RetryOptions>(value: any): T => value
 
@@ -36,7 +36,8 @@ describe('retry', () => {
         bail('iquit')
       })
     } catch (err) {
-      expect(err).toBe('iquit')
+      expect(err instanceof Error).toBeTruthy()
+      expect((err as Error).message).toBe('{"_exited":"iquit"}')
       return
     }
     expect.fail('error should have been thrown')
@@ -47,7 +48,8 @@ describe('retry', () => {
         throw 'quitagain'
       })
     } catch (err) {
-      expect(err).toBe('quitagain')
+      expect(err instanceof Error).toBeTruthy()
+      expect((err as Error).message).toBe('"quitagain"')
       return
     }
     expect.fail('error should have been thrown')
@@ -59,7 +61,8 @@ describe('retry', () => {
       }
       await _.retry({ times: 3 }, func)
     } catch (err) {
-      expect(err).toBe('quitagain')
+      expect(err instanceof Error).toBeTruthy()
+      expect((err as Error).message).toBe('"quitagain"')
       return
     }
     expect.fail('error should have been thrown')
@@ -73,7 +76,8 @@ describe('retry', () => {
       vi.advanceTimersByTimeAsync(1000)
       await promise
     } catch (err) {
-      expect(err).toBe('quitagain')
+      expect(err instanceof Error).toBeTruthy()
+      expect((err as Error).message).toBe('"quitagain"')
       return
     }
     expect.fail('error should have been thrown')

--- a/tests/async/tryit.test.ts
+++ b/tests/async/tryit.test.ts
@@ -13,6 +13,44 @@ describe('tryit', () => {
     expect(err).not.toBeNull()
     expect(err!.message).toBe('not good enough')
   })
+  test('returns error when error is thrown, handled as return object', async () => {
+    const fn = _.try(async () => {
+      throw new Error('not good enough')
+    })
+    const either = await fn()
+    expect(_.isLeft(either)).toBeTruthy()
+    expect(_.isRight(either)).toBeFalsy()
+    expect(_.left(either)).not.toBeNull()
+    expect(_.left(either)).not.toBeUndefined()
+    expect(_.right(either)).toBeUndefined()
+    expect(_.left(either).message).toBe('not good enough')
+  })
+  test('Error in async function returns promise of Left', async () => {
+    const fn = _.try(async () => {
+      throw new Error('not good enough')
+    })
+    const either = fn()
+    expect(_.isPromise(either)).toBeTruthy()
+    expect(_.isLeft(await either)).toBeTruthy()
+    expect(_.isRight(await either)).toBeFalsy()
+  })
+  test('Tryit converts non-Error into Error', async () => {
+    const either = _.try(() => {
+      throw 'not good enough'
+    })()
+    expect(_.isEither(either)).toBe(true)
+    expect(_.isLeft(either)).toBe(true)
+    expect(_.isRight(either)).toBe(false)
+    expect(either[0]).toBeInstanceOf(Error)
+  })
+  test('Tryit comverts non-Error into Error async', async () => {
+    const either = _.try(async () => {
+      throw 'not good enough'
+    })()
+    expect(_.isPromise(either)).toBe(true)
+    expect(_.isLeft(await either)).toBe(true)
+    expect((await either)[0]).toBeInstanceOf(Error)
+  })
   test('returns result when no error is thrown', async () => {
     const [err, result] = await _.try(async () => {
       return 'hello'
@@ -21,6 +59,37 @@ describe('tryit', () => {
     expect(result).not.toBeNull()
     expect(result).toBe('hello')
   })
+  test('returns Right Either when no error is thrown', async () => {
+    const either = _.try(() => {
+      return 'hello'
+    })()
+    expect(_.isEither(either)).toBe(true)
+    expect(_.isRight(either)).toBe(true)
+    expect(_.right(either)).toBe('hello')
+  })
+
+  test('Must pass Error object to createLeft', async () => {
+    //@ts-expect-error
+    const either = _.createLeft('fault')
+  })
+
+  test('createLeft creates a Left Either', async () => {
+    const either = _.createLeft(new Error('fault'))
+    expect(_.isEither(either)).toBe(true)
+    expect(_.isLeft(either)).toBe(true)
+    expect(_.isRight(either)).toBe(false)
+    expect(_.left(either)).toBeInstanceOf(Error)
+    expect(_.left(either).message).toBe('fault')
+  })
+
+  test('createRight creates a Right Either', async () => {
+    const either = _.createRight('success')
+    expect(_.isEither(either)).toBe(true)
+    expect(_.isRight(either)).toBe(true)
+    expect(_.isLeft(either)).toBe(false)
+    expect(_.right(either)).toBe('success')
+  })
+
   test('handles non-async function results', async () => {
     const [err, result] = _.try(() => {
       return 'hello'

--- a/tests/object/crush.test-d.ts
+++ b/tests/object/crush.test-d.ts
@@ -1,0 +1,53 @@
+import * as _ from 'radashi'
+
+describe('crush', () => {
+  test('direct properties are preserved in the result type', () => {
+    const obj = _.crush({ a: 1, b: '2', c: true })
+    expectTypeOf(obj).toEqualTypeOf<{ a: number; b: string; c: boolean }>()
+  })
+  test('nested objects add Record to result type', () => {
+    const obj = _.crush({ a: { b: 1 } })
+    expectTypeOf(obj).toEqualTypeOf<Record<string, unknown>>()
+
+    const obj2 = _.crush({ a: 1, b: { c: 2 } })
+    expectTypeOf(obj2).toEqualTypeOf<{ a: number; [key: string]: unknown }>()
+    expectTypeOf(obj2.a).toEqualTypeOf<number>()
+    expectTypeOf(obj2['b.c']).toEqualTypeOf<unknown>()
+  })
+  test('optional property', () => {
+    const obj = _.crush({} as { a?: number })
+    // FIXME: Try to preserve optionality.
+    expectTypeOf(obj).toEqualTypeOf<{ a: number | undefined }>()
+  })
+  test('crushed Record type', () => {
+    const obj = _.crush({} as Record<number, number>)
+    expectTypeOf(obj).toEqualTypeOf<Record<number, number>>()
+
+    const obj2 = _.crush({} as Record<string, string>)
+    expectTypeOf(obj2).toEqualTypeOf<Record<string, string>>()
+
+    const obj3 = _.crush({} as Record<number, number | object>)
+    expectTypeOf(obj3).toEqualTypeOf<Record<string, unknown>>()
+
+    const obj4 = _.crush({} as Record<string, string | unknown[]>)
+    expectTypeOf(obj4).toEqualTypeOf<Record<string, unknown>>()
+  })
+  test('crushed array', () => {
+    // We cannot assume the keys from "number[]" input value, but we
+    // *can* assume the value type. Note that the value type doesn't
+    // contain "undefined" (which matches array behavior).
+    const obj = _.crush([1, 2, 3])
+    expectTypeOf(obj).toEqualTypeOf<Record<string, number>>()
+
+    const obj2 = _.crush([1, { b: 2 }])
+    expectTypeOf(obj2).toEqualTypeOf<Record<string, unknown>>()
+    expectTypeOf(obj2[0]).toEqualTypeOf<unknown>()
+  })
+  test('union type with object and primitive', () => {
+    // Since "a" may be an object, we cannot assume the result will
+    // have an "a" property. Therefore, the keys and values of the
+    // result are unknown.
+    const obj = _.crush({ a: {} as number | object })
+    expectTypeOf(obj).toEqualTypeOf<Record<string, unknown>>()
+  })
+})

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,4 +33,12 @@ describe('crush', () => {
       timestamp: now,
     })
   })
+  test('handles property names with dots', () => {
+    const obj = {
+      a: { 'b.c': 'value' }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c': 'value'
+    })
+  })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,12 +33,36 @@ describe('crush', () => {
       timestamp: now,
     })
   })
-  test('handles property names with dots', () => {
+  test('handles property names with dots 1', () => {
     const obj = {
       a: { 'b.c': 'value' }
     }
     expect(_.crush(obj)).toEqual({
       'a.b.c': 'value'
+    })
+  })
+  test('handles property names with dots 2', () => {
+    const obj = {
+      'a.b': { c: 'value' }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c': 'value'
+    })
+  })
+  test('handles property names with dots 3', () => {
+    const obj = {
+      'a.b': { 'c.d': 123.4 }
+    }
+    expect(_.crush(obj)).toEqual({
+      'a.b.c.d': 123.4
+    })
+  })
+  test('handles arrays', () => {
+    const obj = ['value', 123.4, true]
+    expect(_.crush(obj)).toEqual({
+      '0': 'value',
+      '1': 123.4,
+      '2': true
     })
   })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -33,36 +33,67 @@ describe('crush', () => {
       timestamp: now,
     })
   })
-  test('handles property names with dots 1', () => {
-    const obj = {
-      a: { 'b.c': 'value' },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value',
-    })
-  })
-  test('handles property names with dots 2', () => {
-    const obj = {
-      'a.b': { c: 'value' },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value',
-    })
-  })
-  test('handles property names with dots 3', () => {
-    const obj = {
-      'a.b': { 'c.d': 123.4 },
-    }
-    expect(_.crush(obj)).toEqual({
-      'a.b.c.d': 123.4,
-    })
-  })
   test('handles arrays', () => {
     const obj = ['value', 123.4, true]
     expect(_.crush(obj)).toEqual({
       '0': 'value',
       '1': 123.4,
       '2': true,
+    })
+  })
+  describe('property names containing period', () => {
+    test('inside the root object', () => {
+      const obj = {
+        'a.b': { c: 'value' },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c': 'value',
+      })
+    })
+    test('inside a nested object', () => {
+      const obj = {
+        a: { 'b.c': 'value' },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c': 'value',
+      })
+    })
+    test('inside both root and nested object', () => {
+      const obj = {
+        'a.b': { 'c.d': 123.4 },
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.c.d': 123.4,
+      })
+    })
+    test('crush array containing object with nested property', () => {
+      const arr = [{ 'c.d': { 'e.f': 'g' } }]
+      const obj = {
+        'a.b': arr,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b.0.c.d.e.f': 'g',
+      })
+    })
+    test('do not crush Date objects', () => {
+      const date = new Date()
+      const obj = {
+        'a.b': date,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b': date,
+      })
+    })
+    test('do not crush Map objects', () => {
+      const map = new Map()
+      map.set('a', 'b')
+      map.set('c', 'd')
+      const obj = {
+        'a.b': map,
+      }
+      expect(_.crush(obj)).toEqual({
+        'a.b': map,
+      })
     })
   })
 })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -35,26 +35,26 @@ describe('crush', () => {
   })
   test('handles property names with dots 1', () => {
     const obj = {
-      a: { 'b.c': 'value' }
+      a: { 'b.c': 'value' },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value'
+      'a.b.c': 'value',
     })
   })
   test('handles property names with dots 2', () => {
     const obj = {
-      'a.b': { c: 'value' }
+      'a.b': { c: 'value' },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c': 'value'
+      'a.b.c': 'value',
     })
   })
   test('handles property names with dots 3', () => {
     const obj = {
-      'a.b': { 'c.d': 123.4 }
+      'a.b': { 'c.d': 123.4 },
     }
     expect(_.crush(obj)).toEqual({
-      'a.b.c.d': 123.4
+      'a.b.c.d': 123.4,
     })
   })
   test('handles arrays', () => {
@@ -62,7 +62,7 @@ describe('crush', () => {
     expect(_.crush(obj)).toEqual({
       '0': 'value',
       '1': 123.4,
-      '2': true
+      '2': true,
     })
   })
 })


### PR DESCRIPTION
## Summary

Refines the `tryit` function by improving it's typings
`Left` (for failed) and `Right` (for successfull) types added
`Either` (Left or Right) and `Task` (async Either) types added
`isEither`, `isLeft` and `isRight` type guard functions added

This is the first of two PR's, in a second PR I would like to create a `pipe` function equivalent to `chain` but that also handles error states and both sync and async functions.

I ran into a problem with the `retry` tests because these use `try` with non-Error fault handling which I believe is not sound - I changes the tests.

## Related issue, if any:

None

## For any code change,
- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?
Yes - `tryit()` will always return an error object if an `Error` is thrown in the function

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._
