### PR TITLE
feat: add types for Ok/Err/Result/ResultPromise

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,72 @@ export type Intersect<U> = (U extends any ? (k: U) => void : never) extends (
 export type Simplify<T> = {} & { [P in keyof T]: T[P] }
 
 /**
+ * A result tuple where the error is `undefined`.
+ *
+ * @example
+ * ```ts
+ * type GoodResult = Ok<string>
+ * //   ^? [undefined, string]
+ * ```
+ */
+export type Ok<TResult> = [err: undefined, result: TResult]
+
+/**
+ * A result tuple where an error is included.
+ *
+ * Note that `TError` is non-nullable, which means that
+ * `Err<undefined>` and `Err<null>` are not valid.
+ *
+ * @example
+ * ```ts
+ * type BadResult = Err
+ * //   ^? [Error, undefined]
+ *
+ * type BadResult2 = Err<TypeError | MyCoolCustomError>
+ * //   ^? [TypeError | MyCoolCustomError, undefined]
+ * ```
+ */
+export type Err<TError = Error> = [err: NonNullable<TError>, result: undefined]
+
+/**
+ * A result tuple.
+ *
+ * First index is the error, second index is the result.
+ *
+ * @example
+ * ```ts
+ * type MyResult = Result<string>
+ * //   ^? Ok<string> | Err<Error>
+ *
+ * type MyResult2 = Result<string, TypeError>
+ * //   ^? Ok<string> | Err<TypeError>
+ * ```
+ */
+export type Result<TResult, TError = Error> =
+  | Ok<TResult>
+  | Err<NonNullable<TError>>
+
+/**
+ * A promise that resolves to a result tuple.
+ *
+ * @example
+ * ```ts
+ * type MyResult = ResultPromise<string>
+ * //   ^? Promise<Ok<string> | Err<Error>>
+ *
+ * type MyResult2 = ResultPromise<string, TypeError>
+ * //   ^? Promise<Ok<string> | Err<TypeError>>
+ * ```
+ */
+export type ResultPromise<TResult, TError = Error> = Promise<
+  [NonNullable<TError>] extends [never]
+    ? Ok<TResult>
+    : [TResult] extends [never]
+      ? Err<NonNullable<TError>>
+      : Result<TResult, NonNullable<TError>>
+>
+
+/**
  * Get all properties **not using** the `?:` type operator.
  */
 export type RequiredKeys<T> = T extends any


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

### Added Types

<!-- Describe what the change does and why it should be merged. -->
- **Ok**
    - `Ok<string>` → `[undefined, string]`
    - `Ok<Promise<string>>` → `[undefined, string]`
- **Err**
    - `Err` → `[Error, undefined]`
    - `Err<unknown>` → `[NonNullable<unknown>, undefined]`
    - `Err<Error | string>` → `[Error | string, undefined]`
- **Result**
    - `Result<string>` → `Ok<string> | Err`
    - `Result<string, TypeError>` → `Ok<string> | Err<TypeError>`
- **ResultPromise**
    - `ResultPromise<string>` → `Promise<Ok<string> | Err>`
    - `ResultPromise<string, TypeError>` → `Promise<Ok<string> | Err<TypeError>>`

The goal is to keep these types as straight-forward as possible.

### Added Functions

- `isResult`: Check if some value is an `Ok` or `Err` result.
- `isResultOk`: Check if some value is an `Ok` result.
- `isResultErr`: Check if some value is an `Err` result.

### Etymology

The `Ok<T>` and `Err<E>` convention for representing success and error states in a type-safe manner originates from the Rust programming language. This pattern is known as the Result type in Rust.

In Rust, the `Result<T, E>` enum is used to return and propagate errors. It has two variants:

1. `Ok(T)`: Represents a successful result, containing a value of type T.
2. `Err(E)`: Represents an error, containing an error value of type E.

This pattern has been adopted by other languages and libraries due to its effectiveness in handling errors and optional values in a type-safe way. It's similar to the Either type in functional programming, where Left typically represents an error and Right represents a success value.

The `Ok<T>` and `Err<E>` convention offers several benefits:

1. Explicit error handling: Forces developers to consider both success and error cases.
2. Type safety: Provides compile-time checks for proper error handling.
3. Composability: Allows for easy chaining of operations that may fail.
4. Avoiding exceptions for control flow: Represents errors as values rather than using exceptions.

This approach to error handling and optional values has gained popularity in various programming paradigms due to its clarity and safety advantages over traditional error handling mechanisms.

## Related issue, if any:

Inspired by #131

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->









