### PR TITLE
feat(throttle): add `trigger` method to ThrottleFunction

### DIFF
--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -14,7 +14,10 @@ The function accepts two parameters:
    - `trailing` (optional): If true, also calls the function after the throttle period if it was invoked during the throttle
 2. The function to be throttled
 
-The returned throttled function also includes an `isThrottled` method to check if there's currently an active throttle.
+The returned throttled function also includes these methods:
+
+- `isThrottled(): boolean`: To check if there's currently an active throttle
+- `trigger(...args): void`: To invoke the wrapped function without waiting for the next interval
 
 ```typescript
 import { throttle } from 'radashi'

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -76,11 +76,10 @@ export function throttle<TArgs extends any[]>(
       trailingArgs = undefined
 
       clearTimeout(timer)
-      timer = setTimeout(() => {
-        if (trailingArgs) {
-          trigger(...trailingArgs)
-        }
-      }, interval)
+      timer = setTimeout(
+        () => trailingArgs && trigger(...trailingArgs),
+        interval,
+      )
     }
   })
 

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -11,6 +11,23 @@ export type ThrottledFunction<TArgs extends any[]> = {
    * Call the throttled function immediately, ignoring any throttling
    * that may be in effect. After, a new throttled call will be allowed
    * after the interval has passed.
+   *
+   * @example
+   * ```ts
+   * const logMessage = (message: string) => {
+   *   console.log(`Message: ${message}`)
+   * }
+   * const throttledLog = throttle({ interval: 1000 }, logMessage)
+   *
+   * throttledLog('First call')  // Logs immediately
+   * throttledLog('Throttled')   // Doesn't log (throttled)
+   *
+   * // Force a log, bypassing the throttle
+   * throttledLog.trigger('Forced log')  // Logs immediately
+   *
+   * // Check if it's still throttled
+   * throttledLog.isThrottled()  // => true
+   * ```
    */
   trigger(...args: TArgs): void
 }

--- a/src/curry/throttle.ts
+++ b/src/curry/throttle.ts
@@ -1,4 +1,5 @@
 declare const setTimeout: (fn: () => void, ms: number) => unknown
+declare const clearTimeout: (timer: unknown) => void
 
 export type ThrottledFunction<TArgs extends any[]> = {
   (...args: TArgs): void
@@ -6,6 +7,12 @@ export type ThrottledFunction<TArgs extends any[]> = {
    * Checks if there is any invocation throttled
    */
   isThrottled(): boolean
+  /**
+   * Call the throttled function immediately, ignoring any throttling
+   * that may be in effect. After, a new throttled call will be allowed
+   * after the interval has passed.
+   */
+  trigger(...args: TArgs): void
 }
 
 /**
@@ -29,24 +36,13 @@ export function throttle<TArgs extends any[]>(
   { interval, trailing }: { interval: number; trailing?: boolean },
   func: (...args: TArgs) => any,
 ): ThrottledFunction<TArgs> {
+  let timer: unknown
   let lastCalled = 0
   let trailingArgs: TArgs | undefined
 
   const throttled: ThrottledFunction<TArgs> = (...args: TArgs) => {
     if (!isThrottled()) {
-      func(...args)
-      lastCalled = Date.now()
-
-      if (trailing) {
-        trailingArgs = undefined
-        setTimeout(() => {
-          if (trailingArgs) {
-            func(...trailingArgs)
-            lastCalled = Date.now()
-            trailingArgs = undefined
-          }
-        }, interval)
-      }
+      trigger(...args)
     } else if (trailing) {
       trailingArgs = args
     }
@@ -54,6 +50,22 @@ export function throttle<TArgs extends any[]>(
 
   const isThrottled = () => Date.now() - lastCalled < interval
   throttled.isThrottled = isThrottled
+
+  const trigger = (throttled.trigger = (...args: TArgs) => {
+    func(...args)
+    lastCalled = Date.now()
+
+    if (trailing) {
+      trailingArgs = undefined
+
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (trailingArgs) {
+          trigger(...trailingArgs)
+        }
+      }, interval)
+    }
+  })
 
   return throttled
 }

--- a/tests/curry/throttle.test.ts
+++ b/tests/curry/throttle.test.ts
@@ -2,6 +2,7 @@ import * as _ from 'radashi'
 
 describe('throttle', () => {
   const interval = 600
+  const smidge = 10
 
   beforeEach(() => {
     vi.useFakeTimers()
@@ -14,72 +15,127 @@ describe('throttle', () => {
     func()
     func()
     expect(calls).toBe(1)
-    vi.advanceTimersByTime(interval + 10)
+    vi.advanceTimersByTime(interval + smidge)
     func()
     func()
     func()
     expect(calls).toBe(2)
   })
 
-  test('returns if the throttle is active', async () => {
-    const results = []
-    const func = _.throttle({ interval }, () => {})
-    results.push(func.isThrottled())
-    func()
-    results.push(func.isThrottled())
-    func()
-    results.push(func.isThrottled())
-    func()
-    results.push(func.isThrottled())
-    vi.advanceTimersByTime(interval + 10)
-    results.push(func.isThrottled())
-    assert.deepEqual(results, [false, true, true, true, false])
+  describe('trailing option', () => {
+    test('single call with trailing set to true', async () => {
+      let calls = 0
+      const func = _.throttle({ interval, trailing: true }, () => calls++)
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(interval + smidge)
+      expect(calls).toBe(1)
+    })
+
+    test('repeated calls with trailing set to true', async () => {
+      let calls = 0
+      const func = _.throttle({ interval, trailing: true }, () => calls++)
+      func()
+      expect(calls).toBe(1)
+      vi.advanceTimersByTime(smidge)
+      func()
+      vi.advanceTimersByTime(interval + smidge)
+      expect(calls).toBe(2)
+    })
+
+    test('', async () => {
+      const wrapped = vi.fn()
+      const func = _.throttle({ interval, trailing: true }, wrapped)
+
+      func()
+      func()
+
+      expect(wrapped).toHaveBeenCalledTimes(1)
+
+      // Advance time a bit (but still before the interval).
+      vi.advanceTimersByTime(smidge)
+
+      // Still throttled.
+      func()
+      func()
+
+      expect(wrapped).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(interval)
+
+      // By now, the trailing call should have occurred
+      expect(wrapped).toHaveBeenCalledTimes(2)
+
+      // The trailing call should re-throttle the function.
+      expect(func.isThrottled()).toBe(true)
+
+      // So these will be throttled.
+      func()
+      func()
+      expect(wrapped).toHaveBeenCalledTimes(2)
+
+      vi.advanceTimersByTime(interval + smidge)
+
+      // By now another trailing call should have happened
+      expect(wrapped).toHaveBeenCalledTimes(3)
+    })
   })
 
-  describe('trailing option', () => {
-    test('single call with trailing option is set to `true` calls source function once', async () => {
-      let calls = 0
-      const func = _.throttle({ interval, trailing: true }, () => calls++)
+  describe('isThrottled method', () => {
+    test('returns if the throttle is active', async () => {
+      const results = []
+      const func = _.throttle({ interval }, () => {})
+      results.push(func.isThrottled())
       func()
-      expect(calls).toBe(1)
-      vi.advanceTimersByTime(interval + 10)
-      expect(calls).toBe(1)
+      results.push(func.isThrottled())
+      func()
+      results.push(func.isThrottled())
+      func()
+      results.push(func.isThrottled())
+      vi.advanceTimersByTime(interval + smidge)
+      results.push(func.isThrottled())
+      assert.deepEqual(results, [false, true, true, true, false])
+    })
+  })
+
+  describe('trigger method', () => {
+    test('ignore any throttle in place', () => {
+      const wrapped = vi.fn()
+      const func = _.throttle({ interval }, wrapped)
+
+      func()
+      expect(wrapped).toHaveBeenCalledTimes(1)
+      func()
+      expect(wrapped).toHaveBeenCalledTimes(1)
+      func()
+      expect(wrapped).toHaveBeenCalledTimes(1)
+
+      func.trigger()
+      expect(wrapped).toHaveBeenCalledTimes(2)
     })
 
-    test('repeated calls with trailing option is set to `true` calls source function again on trailing edge', async () => {
-      let calls = 0
-      const func = _.throttle({ interval, trailing: true }, () => calls++)
-      func()
-      expect(calls).toBe(1)
-      vi.advanceTimersByTime(10)
-      func()
-      vi.advanceTimersByTime(interval + 10)
-      expect(calls).toBe(2)
-    })
+    test('clears trailing state', () => {
+      const wrapped = vi.fn()
+      const func = _.throttle({ interval, trailing: true }, wrapped)
 
-    test('with trailing option is set to `true`, throttling is still effective after a trailing invocation', async () => {
-      let calls = 0
-      const func = _.throttle({ interval, trailing: true }, () => calls++)
       func()
-      func()
-      expect(calls).toBe(1)
-      vi.advanceTimersByTime(10)
-      func()
-      func()
-      expect(calls).toBe(1)
-      vi.advanceTimersByTime(interval)
-      // By now, the trailing call should have occurred
-      expect(calls).toBe(2)
+      func() // <-- trailing call
+      func.trigger()
+      expect(wrapped).toHaveBeenCalledTimes(2)
 
-      vi.advanceTimersByTime(10)
-      func()
-      func()
-      // This call should still be throttled
-      expect(calls).toBe(2)
+      // Since trigger was called, the trailing call was cancelled.
+      vi.advanceTimersByTime(interval + smidge)
+      expect(wrapped).toHaveBeenCalledTimes(2)
 
-      vi.advanceTimersByTime(interval + 10)
-      // By now another trailing call should have happened
-      expect(calls).toBe(3)
+      func()
+      func.trigger()
+      func() // <-- trailing call after trigger
+      expect(wrapped).toHaveBeenCalledTimes(4)
+
+      // Since the trailing call was queued after the trigger, it will
+      // still be called.
+      vi.advanceTimersByTime(interval + smidge)
+      expect(wrapped).toHaveBeenCalledTimes(5)
     })
   })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
The `trigger` method lets you skip the throttle queue and invoke the function immediately. This will reset the throttle timeout too.

```ts
const logMessage = (message: string) => {
  console.log(`Message: ${message}`)
}
const throttledLog = throttle({ interval: 1000 }, logMessage)

throttledLog('First call')  // Logs immediately
throttledLog('Throttled')   // Doesn't log (throttled)

// Force a log, bypassing the throttle
throttledLog.trigger('Forced log')  // Logs immediately

// Check if it's still throttled
throttledLog.isThrottled()  // => true
```


## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/curry/throttle.ts` | 262 [^1337] | +26 (+11%) |

[^1337]: Function size includes the `import` dependencies of the function.

