### PR TITLE
feat(draw): add overloads for empty and non-empty arrays

### DIFF
--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -15,8 +15,9 @@ import { random } from 'radashi'
  * // => [1, 2, 3]
  * ```
  */
-export function draw(array: readonly []): null;
-export function draw<T>(array: readonly T[]): T;
+export function draw(array: readonly []): null
+export function draw<T>(array: readonly T[]): T
+
 export function draw<T>(array: readonly T[]): T | null {
   const max = array.length
   if (max === 0) {

--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -15,6 +15,8 @@ import { random } from 'radashi'
  * // => [1, 2, 3]
  * ```
  */
+export function draw(array: readonly []): null;
+export function draw<T>(array: readonly T[]): T;
 export function draw<T>(array: readonly T[]): T | null {
   const max = array.length
   if (max === 0) {


### PR DESCRIPTION
## Summary

The return type of `draw()` does not take emptiness of the array argument into account.

It would be helpful to assert that:
- `null` is returned when array argument is empty
- `T` is returned otherwise

Before:

<img width="357" alt="image" src="https://github.com/user-attachments/assets/781c1e66-f93f-4c49-9f4d-fc6d4ac42060">

After:

<img width="322" alt="image" src="https://github.com/user-attachments/assets/f3e5bbeb-5588-48e3-aad7-768689a10aad">

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Bundle impact

<!-- This is calculated in Github Actions. -->

_Calculating..._
