### PR TITLE
feat(array): narrow return type for `first` and `last`

### DIFF
--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -11,9 +11,11 @@
  * // 0
  * ```
  */
-export function first<T>(array: readonly T[]): T | undefined
+export function first(array: readonly []): undefined
+export function first<T>(array: readonly T[]): T
 
-export function first<T, U>(array: readonly T[], defaultValue: U): T | U
+export function first<U>(array: readonly [], defaultValue: U): U
+export function first<T, U>(array: readonly T[], defaultValue: U): T
 
 export function first(array: readonly unknown[], defaultValue?: unknown) {
   return array?.length > 0 ? array[0] : defaultValue

--- a/src/array/last.ts
+++ b/src/array/last.ts
@@ -11,9 +11,11 @@
  * // 0
  * ```
  */
-export function last<T>(array: readonly T[]): T | undefined
+export function last(array: readonly []): undefined
+export function last<T>(array: readonly T[]): T
 
-export function last<T, U>(array: readonly T[], defaultValue: U): T | U
+export function last<U>(array: readonly [], defaultValue: U): U
+export function last<T, U>(array: readonly T[], defaultValue: U): T
 
 export function last(array: readonly unknown[], defaultValue?: unknown) {
   return array?.length > 0 ? array[array.length - 1] : defaultValue


### PR DESCRIPTION
## Summary

Similarly to #139, we can narrow the return types for `first()` and `last()` based on the emptiness of the argument.

Before:

<img width="457" alt="image" src="https://github.com/user-attachments/assets/7bb35c42-a7f8-47e6-881b-0bd2e74390a9">

After:

<img width="422" alt="image" src="https://github.com/user-attachments/assets/7ebe0c88-1ce2-4154-9e92-cb73fc4e1414">

## For any code change,

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No

