### PR TITLE
feat(assign): refine types

### DIFF
--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -17,10 +17,7 @@ import { isPlainObject } from 'radashi'
 export function assign<
   X extends Record<string | symbol | number, any>,
   Y extends Record<string | symbol | number, any>,
->(
-  initial: X,
-  override: Y,
-): X & Y {
+>(initial: X, override: Y): X & Y {
   if (!initial || !override) {
     return initial ?? override ?? {}
   }

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -14,10 +14,13 @@ import { isPlainObject } from 'radashi'
  * // => { a: 1, b: 2, c: 3, p: { a: 4, b: 5 } }
  * ```
  */
-export function assign<X extends Record<string | symbol | number, any>>(
+export function assign<
+  X extends Record<string | symbol | number, any>,
+  Y extends Record<string | symbol | number, any>,
+>(
   initial: X,
-  override: X,
-): X {
+  override: Y,
+): X & Y {
   if (!initial || !override) {
     return initial ?? override ?? {}
   }


### PR DESCRIPTION
## Summary

The type declaration with `assign` (mistakenly?) requires that both arguments have the same shape.

Taking the example from the docs:

<img width="512" alt="image" src="https://github.com/user-attachments/assets/22eb6a82-e0d8-42a8-8e0e-0fd17ff4a55d">

Two warnings:

<img width="891" alt="image" src="https://github.com/user-attachments/assets/2d563d74-ec0f-4aa1-9e8b-82b1e0326c5b">

<img width="411" alt="image" src="https://github.com/user-attachments/assets/3ad6f4cb-2e76-499d-b143-0eec9120ebc4">

After:

<img width="514" alt="image" src="https://github.com/user-attachments/assets/86fcd936-ae5e-4f10-9047-4a0fc8f8f808">

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No

