### PR TITLE
fix(types): make `assign` return type more accurate + add `Assign` type

### DIFF
--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -113,7 +113,7 @@ type AtomicValue = BuiltInType | CustomClass | BoxedPrimitive
  * unmergeable and `{ n: number }` as mergeable.
  */
 type AssignDeep<TInitial, TOverride, IsOptional = false> =
-  | never // <-- ignore me!
+  | never // ← Fixes auto-formatting of the comment below.
   /**
    * When a native type is found in TInitial, it will only exist in
    * the result type if the override is optional.

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -1,4 +1,12 @@
-import { isPlainObject } from 'radashi'
+import {
+  isPlainObject,
+  type BoxedPrimitive,
+  type BuiltInType,
+  type CustomClass,
+  type IsExactType,
+  type OptionalKeys,
+  type RequiredKeys,
+} from 'radashi'
 
 /**
  * Create a copy of the first object, and then merge the second object
@@ -14,12 +22,12 @@ import { isPlainObject } from 'radashi'
  * // => { a: 1, b: 2, c: 3, p: { a: 4, b: 5 } }
  * ```
  */
-export function assign<X extends Record<string | symbol | number, any>>(
-  initial: X,
-  override: X,
-): X {
+export function assign<
+  TInitial extends Record<keyof any, any>,
+  TOverride extends Record<keyof any, any>,
+>(initial: TInitial, override: TOverride): Assign<TInitial, TOverride> {
   if (!initial || !override) {
-    return initial ?? override ?? {}
+    return (initial ?? override ?? {}) as any
   }
   const proto = Object.getPrototypeOf(initial)
   const merged = proto
@@ -33,3 +41,117 @@ export function assign<X extends Record<string | symbol | number, any>>(
   }
   return merged
 }
+
+/**
+ * The return type for `assign`.
+ *
+ * It recursively merges object types that are not native objects. The
+ * root objects are always merged.
+ *
+ * @see https://radashi-org.github.io/reference/object/assign
+ */
+export type Assign<
+  TInitial extends object,
+  TOverride extends object,
+> = TInitial extends any
+  ? TOverride extends any
+    ? SimplifyMutable<
+        Omit<TInitial, keyof TOverride> &
+          Omit<TOverride, keyof TInitial> &
+          (Pick<
+            TInitial,
+            keyof TInitial & keyof TOverride
+          > extends infer TConflictInitial
+            ? Pick<
+                TOverride,
+                keyof TInitial & keyof TOverride
+              > extends infer TConflictOverride
+              ? {
+                  [K in RequiredKeys<TConflictOverride>]: AssignDeep<
+                    TConflictInitial[K & keyof TConflictInitial],
+                    TConflictOverride[K]
+                  >
+                } & {
+                  [K in RequiredKeys<TConflictInitial> &
+                    OptionalKeys<TConflictOverride>]: AssignDeep<
+                    TConflictInitial[K],
+                    TConflictOverride[K],
+                    true
+                  >
+                } & {
+                  [K in OptionalKeys<TConflictInitial> &
+                    OptionalKeys<TConflictOverride>]?: AssignDeep<
+                    TConflictInitial[K],
+                    TConflictOverride[K],
+                    true
+                  >
+                }
+              : unknown
+            : unknown)
+      >
+    : never
+  : never
+
+/**
+ * Mimic the `Simplify` type and also remove `readonly` modifiers.
+ */
+type SimplifyMutable<T> = {} & {
+  -readonly [P in keyof T]: T[P]
+}
+
+/**
+ * This represents a value that should only be replaced if it exists
+ * as an initial value; never deeply assigned into.
+ */
+type AtomicValue = BuiltInType | CustomClass | BoxedPrimitive
+
+/**
+ * Handle mixed types when merging nested plain objects.
+ *
+ * For example, if the type `TOverride` includes both `string` and `{ n:
+ * number }` in a union, `AssignDeep` will treat `string` as
+ * unmergeable and `{ n: number }` as mergeable.
+ */
+type AssignDeep<TInitial, TOverride, IsOptional = false> =
+  | never // <-- ignore me!
+  /**
+   * When a native type is found in TInitial, it will only exist in
+   * the result type if the override is optional.
+   */
+  | (TInitial extends AtomicValue
+      ? IsOptional extends true
+        ? TInitial
+        : never
+      : never)
+  /**
+   * When a native type is found in TOverride, it will always exists
+   * in the result type.
+   */
+  | (TOverride extends AtomicValue ? TOverride : never)
+  /**
+   * Deep assignment is handled in this branch.
+   *
+   * 1. Exclude any native types from TInitial and TOverride
+   * 2. If a non-native object type is not found in TInitial, simply
+   *    replace TInitial (or use "A | B" if the override is optional)
+   * 3. For each non-native object type in TOverride, deep assign to
+   *    every non-native object in TInitial
+   * 4. For each non-object type in TOverride, simply replace TInitial
+   *    (or use "A | B" if the override is optional)
+   */
+  | (Exclude<TOverride, AtomicValue> extends infer TOverride // 1.
+      ? Exclude<TInitial, Exclude<AtomicValue, void>> extends infer TInitial
+        ? [Extract<TInitial, object>] extends [never] // 2.
+          ? TOverride | (IsOptional extends true ? TInitial : never)
+          : TInitial extends object
+            ? TOverride extends object
+              ? IsExactType<TOverride, TInitial> extends true
+                ? TOverride
+                : Assign<TInitial, TOverride> // 3.
+              : // 4.
+                TOverride | (IsOptional extends true ? TInitial : never)
+            :
+                | Extract<TOverride, object>
+                | (IsOptional extends true ? TInitial : never)
+        : never
+      : never)

--- a/tests/object/assign.test-d.ts
+++ b/tests/object/assign.test-d.ts
@@ -1,0 +1,197 @@
+import { assign } from 'radashi'
+
+// For testing `assign` with custom class instances.
+class Data {
+  constructor(public data: number) {}
+}
+
+// This declaration tells `assign` to never merge plain objects into
+// our Data class.
+declare module 'radashi' {
+  interface CustomClassRegistry {
+    Data: Data
+  }
+}
+
+describe('assign', () => {
+  test('assign property with native object', () => {
+    const initial = {} as { a: RegExp }
+    const override = {} as { a: Date }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: Date
+    }>()
+  })
+
+  test('assign property with primitive value', () => {
+    const initial = {} as { a: number }
+    const override = {} as { a: string }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: string
+    }>()
+  })
+
+  test('assign property with optional primitive value', () => {
+    const initial = {} as { a: number }
+    const override = {} as { a?: string }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: number | string | undefined
+    }>()
+  })
+
+  test('assign optional property with primitive value', () => {
+    const initial = {} as { a?: number }
+    const override = {} as { a: string }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: string
+    }>()
+  })
+
+  test('assign optional property with optional primitive value', () => {
+    const initial = {} as { a?: number }
+    const override = {} as { a?: string }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a?: string | number
+    }>()
+  })
+
+  test('assign Map property with Map', () => {
+    const initial = {} as { a: Map<number, string> }
+    const override = {} as { a: Map<string, string> }
+    const result = assign(initial, override)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: Map<string, string>
+    }>()
+  })
+
+  describe('nested arrays', () => {
+    test('assign array property with array of primitives', () => {
+      const initial = {} as { a: number[] }
+      const override = {} as { a: string[] }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: string[]
+      }>()
+    })
+
+    test('assign array property with array of objects', () => {
+      const initial = {} as { a: { b: number }[] }
+      const override = {} as { a: { b: string }[] }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string }[]
+      }>()
+    })
+  })
+
+  describe('nested objects', () => {
+    test('assign Map property with object', () => {
+      const initial = {} as { a: Map<number, { b: number }> }
+      const override = {} as { a: { b: string } }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string }
+      }>()
+    })
+
+    test('assign object property with object', () => {
+      const initial = {} as { a: { b: number; c: number } }
+      const override = {} as { a: { b: string; b2?: string } }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string; b2?: string; c: number }
+      }>()
+    })
+
+    test('assign optional object property with object', () => {
+      const initial = {} as { a?: { b: number; c: number } | null | undefined }
+      const override = {} as { a: { b: string } }
+      const result = assign(initial, override)
+
+      // Since the initial "a" property is optional, there exist two
+      // possible object types for "a" in the result type; one with "c"
+      // and one without.
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string; c: number } | { b: string }
+      }>()
+    })
+
+    test('assign object property with optional object and optional properties', () => {
+      const initial = {} as { a: { b: number; c: number } }
+      const override = {} as { a?: { b?: string } }
+      const result = assign(initial, override)
+
+      // When "exactOptionalPropertyTypes" is undefined or false in the
+      // tsconfig, we can't be sure if an optional property is actually
+      // omitted or if its value was set to undefined. For that reason,
+      // the resulting "a" property type must contain an `undefined`
+      // type.
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string | number | undefined; c: number } | undefined
+      }>()
+    })
+
+    test('deep object property', () => {
+      const initial = {} as { a: { b: { c: number; d: number } } }
+      const override = {} as { a: { b: { c: string }; x: string } }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: { c: string; d: number }; x: string }
+      }>()
+    })
+  })
+
+  describe('nested class instances', () => {
+    test('override instance with instance', () => {
+      const initial = {} as { a: Data; c?: number }
+      const override = {} as { a: Data; b: string }
+      // Note: "Data" should be the type, not "{ data: number }"
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: Data
+        b: string
+        c?: number
+      }>()
+    })
+
+    // This relies on the fact that we registered Data with the
+    // CustomClassRegistry type.
+    test('override instance with object', () => {
+      const initial = {} as { a: Data }
+      const override = {} as { a: { b: string } }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: { b: string }
+      }>()
+    })
+
+    // This relies on the fact that we registered Data with the
+    // CustomClassRegistry type.
+    test('override object with instance', () => {
+      const initial = {} as { a: { b: string } }
+      const override = {} as { a: Data }
+      const result = assign(initial, override)
+
+      expectTypeOf(result).toEqualTypeOf<{
+        a: Data
+      }>()
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDeclarationOnly": true,
     "isolatedDeclarations": true,
     "target": "esnext",
-    "lib": ["es2020"],
+    "lib": ["esnext", "dom"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
- Add the `Assign` type, which tries to be as accurate as possible.
- Add the `BuiltInType` utility type as a union type of all built-in types (including DOM-specific and NodeJS-specific types when possible).
- Add the `OptionalKeys` and `RequiredKeys` utility types.

### CustomClassRegistry

Since there's no built-in way to differentiate a “plain object” type and a custom class instance type, I've added the `CustomClassRegistry` interface. Anyone can extend this in their project by using “declaration merging”:

```ts
class FooBar {
  foo: unknown
  bar: unknown
}

declare module 'radashi' {
  interface CustomClassRegistry {
    FooBar: FooBar
  }
}
```

Now the `assign` function's return type won't suggest that `FooBar` instances were merged with. Check out this before-and-after example:

```ts
// BEFORE
const result = assign(
  { a: new FooBar },
  { a: { foo: '' } }
)
// ^? result: { a: { foo: string; bar: unknown } }

// AFTER
const result = assign(
  { a: new FooBar },
  { a: { foo: '' } }
)
// ^? result: { a: { foo: string } }
```

**BEWARE:** Any class you add to `CustomClassRegistry` **must not** have identical properties as any other “plain object” types you ever plan to use, because as far as TypeScript is concerned, they are identical. This could lead to suboptimal result types.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Resolves #141 (cc @crishoj)

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/object/assign.ts` | 373 [^1337] | +0 (+0%) |

[^1337]: Function size includes the `import` dependencies of the function.



