### PR TITLE
feat(castComparator): accept an array of mapping values for fallback comparisons

### DIFF
--- a/src/function/castComparator.ts
+++ b/src/function/castComparator.ts
@@ -6,6 +6,7 @@ import {
   type MappedInput,
   type MappedOutput,
   type Mapping,
+  type Single,
 } from 'radashi'
 
 /**
@@ -127,5 +128,3 @@ export type ComparatorMapping<
   T = any,
   Compared extends Comparable = Comparable,
 > = Mapping<T, Compared> | Mapping<T, Compared>[]
-
-type Single<T> = T extends readonly (infer U)[] ? U : T

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,3 +124,17 @@ export type Intersect<U> = (U extends any ? (k: U) => void : never) extends (
  * @see https://github.com/microsoft/TypeScript/issues/15300
  */
 export type Simplify<T> = {} & { [P in keyof T]: T[P] }
+
+/**
+ * Extract the element type from an array or tuple, or return the type
+ * itself if it is not an array-like type.
+ *
+ * @example
+ * ```ts
+ * type A = Single<string>
+ * //   ^? string
+ * type B = Single<readonly string[]>
+ * //   ^? string
+ * ```
+ */
+export type Single<T> = T extends readonly (infer U)[] ? U : T


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Allow `castComparator` to receive an array of mapping values.

```ts
/**
 * Example usage of castComparator with an array of mappings for fallback comparisons
 */
const sortPeople = castComparator([
  'lastName',
  'firstName',
  person => person.birthDate.getTime()
]);

const people = [
  { firstName: 'John', lastName: 'Doe', birthDate: new Date(1990, 5, 15) },
  { firstName: 'Jane', lastName: 'Doe', birthDate: new Date(1992, 8, 20) },
  { firstName: 'Alice', lastName: 'Smith', birthDate: new Date(1985, 2, 10) }
];

const sortedPeople = people.sort(sortPeople);
// Result:
// [
//   { firstName: 'Jane', lastName: 'Doe', birthDate: Date(1992-09-20) },
//   { firstName: 'John', lastName: 'Doe', birthDate: Date(1990-06-15) },
//   { firstName: 'Alice', lastName: 'Smith', birthDate: Date(1985-03-10) }
// ]
```

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/function/castComparator.ts` | 463 [^1337] | +237 (+104%) |

[^1337]: Function size includes the `import` dependencies of the function.

