### PR TITLE
fix(types): improve `draw` signature for non-empty arrays

### DIFF
--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -16,7 +16,7 @@ import { random } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function draw<T>(arr: readonly [T, ...T[]]): T
+export function draw<T>(array: readonly [T, ...T[]]): T
 export function draw<T>(array: readonly T[]): T | null
 
 export function draw<T>(array: readonly T[]): T | null {

--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -16,8 +16,8 @@ import { random } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function draw(array: readonly []): null
-export function draw<T>(array: readonly T[]): T
+export function draw<T>(arr: readonly [T, ...T[]]): T
+export function draw<T>(array: readonly T[]): T | null
 
 export function draw<T>(array: readonly T[]): T | null {
   const max = array.length

--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -16,6 +16,8 @@ import { random } from 'radashi'
  * ```
  * @version 12.1.0
  */
+export function draw(array: readonly []): null;
+export function draw<T>(array: readonly T[]): T;
 export function draw<T>(array: readonly T[]): T | null {
   const max = array.length
   if (max === 0) {

--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -16,8 +16,9 @@ import { random } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function draw(array: readonly []): null;
-export function draw<T>(array: readonly T[]): T;
+export function draw(array: readonly []): null
+export function draw<T>(array: readonly T[]): T
+
 export function draw<T>(array: readonly T[]): T | null {
   const max = array.length
   if (max === 0) {

--- a/src/random/draw.ts
+++ b/src/random/draw.ts
@@ -16,13 +16,12 @@ import { random } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function draw<T>(array: readonly [T, ...T[]]): T
-export function draw<T>(array: readonly T[]): T | null
-
-export function draw<T>(array: readonly T[]): T | null {
+export function draw<const T extends readonly any[]>(
+  array: T,
+): T extends readonly [any, ...any[]] ? T[number] : T[number] | null {
   const max = array.length
   if (max === 0) {
-    return null
+    return null as any
   }
   const index = random(0, max - 1)
   return array[index]

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -1,0 +1,30 @@
+import * as _ from 'radashi'
+import { expectTypeOf } from 'vitest'
+
+describe('draw types', () => {
+  test('returns null given empty input', () => {
+    const list: unknown[] = []
+    const result = _.draw(list)
+    expect(result).toBeNull()
+  })
+  test('return type is null for empty array literal', () => {
+    expectTypeOf(_.draw([])).toBeNull()
+  })
+  test('return type is not null for non-empty array literal', () => {
+    expectTypeOf(_.draw([1, 2, 3])).toBeNumber()
+  })
+  test('return type is possibly null for mutable array variables', () => {
+    const emptyList: number[] = []
+    const filledList = [1, 2, 3]
+    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number|null>()
+    expectTypeOf(_.draw(filledList)).toEqualTypeOf<number|null>()
+  })
+  test('return type is null for immutable empty array variables', () => {
+    const emptyList: number[] = [] as const
+    expectTypeOf(_.draw(emptyList)).toBeNull()
+  })
+  test('return type is not null for immutable non-empty array variables', () => {
+    const filledList = [1, 2, 4] as const
+    expectTypeOf(_.draw(filledList)).toBeNumber()
+  })
+})

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -26,6 +26,6 @@ describe('draw types', () => {
   })
   test('return type is not null for immutable non-empty array variables', () => {
     const filledList = [1, 2, 4] as const
-    expectTypeOf(_.draw(filledList)).toBeNumber()
+    expectTypeOf(_.draw(filledList)).toEqualTypeOf<1 | 2 | 4>()
   })
 })

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -1,27 +1,31 @@
 import * as _ from 'radashi'
 
-describe('draw types', () => {
-  test('return type with literal argument', () => {
-    expectTypeOf(_.draw([])).toBeNull()
-    expectTypeOf(_.draw([1, 2, 3])).toBeNumber()
-  })
-  test('return type with mutable variable', () => {
-    const neverList: never[] = []
+describe('draw', () => {
+  test('variable with mutable array', () => {
     const emptyList: number[] = []
     const filledList = [1, 2, 3]
 
-    expectTypeOf(_.draw(neverList)).toEqualTypeOf<null>()
     expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
     expectTypeOf(_.draw(filledList)).toEqualTypeOf<number | null>()
   })
-  test('return type with immutable variable', () => {
-    const neverList: never[] = [] as const
-    const emptyList: number[] = [] as const
+
+  test('variable with empty array', () => {
+    const neverList: never[] = []
+    const emptyList = [] as const
+
+    expectTypeOf(_.draw(neverList)).toEqualTypeOf<null>()
+    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<null>()
+  })
+
+  test('variable with tuple', () => {
     const filledList = [1, 2, 3] as const
 
-    expectTypeOf(_.draw(neverList)).toBeNull()
-    // FIXME: Can this be narrowed to `null`?
-    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
     expectTypeOf(_.draw(filledList)).toEqualTypeOf<1 | 2 | 3>()
+  })
+
+  test('inlined array', () => {
+    expectTypeOf(_.draw([])).toEqualTypeOf<null>()
+    expectTypeOf(_.draw([1, 2, 3])).toEqualTypeOf<number>()
+    expectTypeOf(_.draw([1, 2, 3] as const)).toEqualTypeOf<1 | 2 | 3>()
   })
 })

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -2,30 +2,27 @@ import * as _ from 'radashi'
 
 describe('draw', () => {
   test('variable with mutable array', () => {
-    const emptyList: number[] = []
-    const filledList = [1, 2, 3]
+    const array = [1, 2, 3]
 
-    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
-    expectTypeOf(_.draw(filledList)).toEqualTypeOf<number | null>()
+    expectTypeOf(_.draw(array)).toEqualTypeOf<number | null>()
   })
 
   test('variable with empty array', () => {
-    const neverList: never[] = []
-    const emptyList = [] as const
+    const emptyArray = [] as never[]
+    const emptyTuple = [] as const
 
-    expectTypeOf(_.draw(neverList)).toEqualTypeOf<null>()
-    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<null>()
+    expectTypeOf(_.draw(emptyArray)).toEqualTypeOf<null>()
+    expectTypeOf(_.draw(emptyTuple)).toEqualTypeOf<null>()
   })
 
   test('variable with tuple', () => {
-    const filledList = [1, 2, 3] as const
+    const tuple = [1, 2, 3] as const
 
-    expectTypeOf(_.draw(filledList)).toEqualTypeOf<1 | 2 | 3>()
+    expectTypeOf(_.draw(tuple)).toEqualTypeOf<1 | 2 | 3>()
   })
 
   test('inlined array', () => {
     expectTypeOf(_.draw([])).toEqualTypeOf<null>()
-    expectTypeOf(_.draw([1, 2, 3])).toEqualTypeOf<number>()
-    expectTypeOf(_.draw([1, 2, 3] as const)).toEqualTypeOf<1 | 2 | 3>()
+    expectTypeOf(_.draw([1, 2, 3])).toEqualTypeOf<1 | 2 | 3>()
   })
 })

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -19,9 +19,10 @@ describe('draw types', () => {
     expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
     expectTypeOf(_.draw(filledList)).toEqualTypeOf<number | null>()
   })
-  test('return type is null for immutable empty array variables', () => {
+  test('return type is possibly null for immutable empty array variables', () => {
     const emptyList: number[] = [] as const
-    expectTypeOf(_.draw(emptyList)).toBeNull()
+    // FIXME: Can be narrowed to `null`
+    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
   })
   test('return type is not null for immutable non-empty array variables', () => {
     const filledList = [1, 2, 4] as const

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -2,30 +2,27 @@ import * as _ from 'radashi'
 import { expectTypeOf } from 'vitest'
 
 describe('draw types', () => {
-  test('returns null given empty input', () => {
-    const list: unknown[] = []
-    const result = _.draw(list)
-    expect(result).toBeNull()
-  })
-  test('return type is null for empty array literal', () => {
+  test('return type with literal argument', () => {
     expectTypeOf(_.draw([])).toBeNull()
-  })
-  test('return type is not null for non-empty array literal', () => {
     expectTypeOf(_.draw([1, 2, 3])).toBeNumber()
   })
-  test('return type is possibly null for mutable array variables', () => {
+  test('return type with mutable variable', () => {
+    const neverList: never[] = []
     const emptyList: number[] = []
     const filledList = [1, 2, 3]
+
+    expectTypeOf(_.draw(neverList)).toEqualTypeOf<null>()
     expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
     expectTypeOf(_.draw(filledList)).toEqualTypeOf<number | null>()
   })
-  test('return type is possibly null for immutable empty array variables', () => {
+  test('return type with immutable variable', () => {
+    const neverList: never[] = [] as const
     const emptyList: number[] = [] as const
-    // FIXME: Can be narrowed to `null`
+    const filledList = [1, 2, 3] as const
+
+    expectTypeOf(_.draw(neverList)).toBeNull()
+    // FIXME: Can this be narrowed to `null`?
     expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
-  })
-  test('return type is not null for immutable non-empty array variables', () => {
-    const filledList = [1, 2, 4] as const
-    expectTypeOf(_.draw(filledList)).toEqualTypeOf<1 | 2 | 4>()
+    expectTypeOf(_.draw(filledList)).toEqualTypeOf<1 | 2 | 3>()
   })
 })

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -1,5 +1,4 @@
 import * as _ from 'radashi'
-import { expectTypeOf } from 'vitest'
 
 describe('draw types', () => {
   test('return type with literal argument', () => {

--- a/tests/random/draw.test-d.ts
+++ b/tests/random/draw.test-d.ts
@@ -16,8 +16,8 @@ describe('draw types', () => {
   test('return type is possibly null for mutable array variables', () => {
     const emptyList: number[] = []
     const filledList = [1, 2, 3]
-    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number|null>()
-    expectTypeOf(_.draw(filledList)).toEqualTypeOf<number|null>()
+    expectTypeOf(_.draw(emptyList)).toEqualTypeOf<number | null>()
+    expectTypeOf(_.draw(filledList)).toEqualTypeOf<number | null>()
   })
   test('return type is null for immutable empty array variables', () => {
     const emptyList: number[] = [] as const


### PR DESCRIPTION
## Summary

This is a renewed attempt at narrowing the return type for `draw()`, so that emptiness of the array argument is taken into account.

- For literal array arguments, return type can be determined as `T` or `null`.
- For mutable array arguments, return type remains `T|null`.
- For immutable array arguments, 
  - return type remains `T|null` for empty arrays (not sure why)
  - return type is narrowed to `T` for non-empty arrays.

<img width="448" alt="image" src="https://github.com/user-attachments/assets/8833c849-236a-44cf-bac5-68a80509f446">

---

Disclosure: I am a Typescript novice and welcome your feedback.

If the approach is sound, similar overrides could be considered for
- `first`
- `last`

## Related issue, if any:

- Previous attempt: #139 

## For any code change,

- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

No



