### PR TITLE
fix(types): narrow return type of `first` and `last`

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -12,4 +12,4 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 Previously, `first` and `last` would return `T | undefined`, making subsequent use of the returned value prone to Typescript warnings. 
 
-With return type narrowing, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const`), return type will be narrowed.     
+With return type narrowing in https://github.com/radashi-org/radashi/pull/160, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const` or `readonly`), return type will be narrowed.     

--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -8,8 +8,4 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Features
 
-#### Return type narrowing for `first` and `last`
-
-Previously, `first` and `last` would return `T | undefined`, making subsequent use of the returned value prone to Typescript warnings. 
-
-With return type narrowing, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const`), return type will be narrowed.     
+####

--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -12,4 +12,4 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 Previously, `first` and `last` would return `T | undefined`, making subsequent use of the returned value prone to Typescript warnings. 
 
-With return type narrowing in https://github.com/radashi-org/radashi/pull/160, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const` or `readonly`), return type will be narrowed.     
+With return type narrowing, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const`), return type will be narrowed.     

--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -8,4 +8,8 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Features
 
-####
+#### Return type narrowing for `first` and `last`
+
+Previously, `first` and `last` would return `T | undefined`, making subsequent use of the returned value prone to Typescript warnings. 
+
+With return type narrowing, `first([])` will have return type `undefined`, and `last([1, 2, 3])` will have return type `number`. For mutable arguments, `first` and `last` will still return `T | undefined`, but for immutable arguments (`as const`), return type will be narrowed.     

--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -12,12 +12,14 @@
  * ```
  * @version 12.1.0
  */
-export function first<T>(array: readonly [T, ...T[]]): T
-export function first<T>(array: readonly T[]): T | undefined
-
-export function first<T, U>(array: readonly [T, ...T[]], defaultValue: U): T
-export function first<T, U>(array: readonly T[], defaultValue: U): T | U
-
-export function first(array: readonly unknown[], defaultValue?: unknown) {
+export function first<
+  const TArray extends readonly any[],
+  const TDefault = undefined,
+>(
+  array: TArray,
+  defaultValue?: TDefault,
+): TArray extends readonly [infer TFirst, ...any[]]
+  ? TFirst
+  : TArray[number] | TDefault {
   return array?.length > 0 ? array[0] : defaultValue
 }

--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -12,8 +12,10 @@
  * ```
  * @version 12.1.0
  */
+export function first<T>(array: readonly [T, ...T[]]): T
 export function first<T>(array: readonly T[]): T | undefined
 
+export function first<T, U>(array: readonly [T, ...T[]], defaultValue: U): T
 export function first<T, U>(array: readonly T[], defaultValue: U): T | U
 
 export function first(array: readonly unknown[], defaultValue?: unknown) {

--- a/src/array/last.ts
+++ b/src/array/last.ts
@@ -12,12 +12,14 @@
  * ```
  * @version 12.1.0
  */
-export function last<T>(array: readonly [T, ...T[]]): T
-export function last<T>(array: readonly T[]): T | undefined
-
-export function last<T, U>(array: readonly [T, ...T[]], defaultValue: U): T
-export function last<T, U>(array: readonly T[], defaultValue: U): T | U
-
-export function last(array: readonly unknown[], defaultValue?: unknown) {
+export function last<
+  const TArray extends readonly any[],
+  const TDefault = undefined,
+>(
+  array: TArray,
+  defaultValue?: TDefault,
+): TArray extends readonly [...any[], infer TLast]
+  ? TLast
+  : TArray[number] | TDefault {
   return array?.length > 0 ? array[array.length - 1] : defaultValue
 }

--- a/src/array/last.ts
+++ b/src/array/last.ts
@@ -12,8 +12,10 @@
  * ```
  * @version 12.1.0
  */
+export function last<T>(array: readonly [T, ...T[]]): T
 export function last<T>(array: readonly T[]): T | undefined
 
+export function last<T, U>(array: readonly [T, ...T[]], defaultValue: U): T
 export function last<T, U>(array: readonly T[], defaultValue: U): T | U
 
 export function last(array: readonly unknown[], defaultValue?: unknown) {

--- a/tests/array/first.test-d.ts
+++ b/tests/array/first.test-d.ts
@@ -1,5 +1,4 @@
 import * as _ from 'radashi'
-import { expectTypeOf } from 'vitest'
 
 describe('first types', () => {
   test('return type with literal argument', () => {

--- a/tests/array/first.test-d.ts
+++ b/tests/array/first.test-d.ts
@@ -1,0 +1,54 @@
+import * as _ from 'radashi'
+import { expectTypeOf } from 'vitest'
+
+describe('first types', () => {
+  test('return type with literal argument', () => {
+    expectTypeOf(_.first([])).toBeUndefined()
+    expectTypeOf(_.first([1, 2, 3])).toBeNumber()
+  })
+  test('return type with mutable variable', () => {
+    const neverList: never[] = []
+    const emptyList: number[] = []
+    const filledList = [1, 2, 3]
+
+    expectTypeOf(_.first(neverList)).toEqualTypeOf<undefined>()
+    expectTypeOf(_.first(emptyList)).toEqualTypeOf<number | undefined>()
+    expectTypeOf(_.first(filledList)).toEqualTypeOf<number | undefined>()
+  })
+  test('return type with immutable variable', () => {
+    const neverList: never[] = [] as const
+    const emptyList: number[] = [] as const
+    const filledList = [1, 2, 3] as const
+
+    expectTypeOf(_.first(neverList)).toBeUndefined()
+    // FIXME: Can this be narrowed to `undefined`?
+    expectTypeOf(_.first(emptyList)).toEqualTypeOf<number | undefined>()
+    expectTypeOf(_.first(filledList)).toEqualTypeOf<1 | 2 | 3>()
+  })
+})
+
+describe('first types with default value', () => {
+  test('return type with literal argument', () => {
+    expectTypeOf(_.first([], false)).toBeBoolean()
+    expectTypeOf(_.first([1, 2, 3], false)).toBeNumber()
+  })
+  test('return type with mutable variable', () => {
+    const neverList: never[] = []
+    const emptyList: number[] = []
+    const filledList = [1, 2, 3]
+
+    expectTypeOf(_.first(neverList, false)).toEqualTypeOf<boolean>()
+    expectTypeOf(_.first(emptyList, false)).toEqualTypeOf<number | boolean>()
+    expectTypeOf(_.first(filledList, false)).toEqualTypeOf<number | boolean>()
+  })
+  test('return type with immutable variable', () => {
+    const neverList: never[] = [] as const
+    const emptyList: number[] = [] as const
+    const filledList = [1, 2, 3] as const
+
+    expectTypeOf(_.first(neverList, false)).toBeBoolean()
+    // FIXME: Can this be narrowed to `boolean`?
+    expectTypeOf(_.first(emptyList, false)).toEqualTypeOf<number | boolean>()
+    expectTypeOf(_.first(filledList, false)).toEqualTypeOf<1 | 2 | 3>()
+  })
+})

--- a/tests/array/first.test-d.ts
+++ b/tests/array/first.test-d.ts
@@ -1,53 +1,40 @@
 import * as _ from 'radashi'
 
-describe('first types', () => {
-  test('return type with literal argument', () => {
-    expectTypeOf(_.first([])).toBeUndefined()
-    expectTypeOf(_.first([1, 2, 3])).toBeNumber()
+describe('first', () => {
+  test('inlined array', () => {
+    expectTypeOf(_.first([])).toEqualTypeOf<undefined>()
+    expectTypeOf(_.first([1, 2, 3])).toEqualTypeOf<1>()
   })
-  test('return type with mutable variable', () => {
-    const neverList: never[] = []
-    const emptyList: number[] = []
-    const filledList = [1, 2, 3]
 
-    expectTypeOf(_.first(neverList)).toEqualTypeOf<undefined>()
-    expectTypeOf(_.first(emptyList)).toEqualTypeOf<number | undefined>()
-    expectTypeOf(_.first(filledList)).toEqualTypeOf<number | undefined>()
+  test('variable with empty array', () => {
+    const emptyArray = [] as never[]
+
+    expectTypeOf(_.first(emptyArray)).toEqualTypeOf<undefined>()
   })
-  test('return type with immutable variable', () => {
-    const neverList: never[] = [] as const
-    const emptyList: number[] = [] as const
-    const filledList = [1, 2, 3] as const
 
-    expectTypeOf(_.first(neverList)).toBeUndefined()
-    // FIXME: Can this be narrowed to `undefined`?
-    expectTypeOf(_.first(emptyList)).toEqualTypeOf<number | undefined>()
-    expectTypeOf(_.first(filledList)).toEqualTypeOf<1 | 2 | 3>()
+  test('variable with mutable array', () => {
+    const array = [1, 2, 3]
+
+    expectTypeOf(_.first(array)).toEqualTypeOf<number | undefined>()
   })
-})
 
-describe('first types with default value', () => {
-  test('return type with literal argument', () => {
-    expectTypeOf(_.first([], false)).toBeBoolean()
-    expectTypeOf(_.first([1, 2, 3], false)).toBeNumber()
+  test('variable with readonly tuple', () => {
+    const emptyTuple = [] as const
+    const tuple = [1, 2, 3] as const
+
+    expectTypeOf(_.first(emptyTuple)).toEqualTypeOf<undefined>()
+    expectTypeOf(_.first(tuple)).toEqualTypeOf<1>()
   })
-  test('return type with mutable variable', () => {
-    const neverList: never[] = []
-    const emptyList: number[] = []
-    const filledList = [1, 2, 3]
 
-    expectTypeOf(_.first(neverList, false)).toEqualTypeOf<boolean>()
-    expectTypeOf(_.first(emptyList, false)).toEqualTypeOf<number | boolean>()
-    expectTypeOf(_.first(filledList, false)).toEqualTypeOf<number | boolean>()
-  })
-  test('return type with immutable variable', () => {
-    const neverList: never[] = [] as const
-    const emptyList: number[] = [] as const
-    const filledList = [1, 2, 3] as const
+  test('with default value', () => {
+    const emptyArray = [] as never[]
+    const emptyTuple = [] as const
+    const array = [1, 2, 3]
+    const tuple = [1, 2, 3] as const
 
-    expectTypeOf(_.first(neverList, false)).toBeBoolean()
-    // FIXME: Can this be narrowed to `boolean`?
-    expectTypeOf(_.first(emptyList, false)).toEqualTypeOf<number | boolean>()
-    expectTypeOf(_.first(filledList, false)).toEqualTypeOf<1 | 2 | 3>()
+    expectTypeOf(_.first(emptyArray, false)).toEqualTypeOf<false>()
+    expectTypeOf(_.first(emptyTuple, false)).toEqualTypeOf<false>()
+    expectTypeOf(_.first(array, false)).toEqualTypeOf<number | false>()
+    expectTypeOf(_.first(tuple, false)).toEqualTypeOf<1>()
   })
 })

--- a/tests/array/last.test-d.ts
+++ b/tests/array/last.test-d.ts
@@ -1,53 +1,40 @@
 import * as _ from 'radashi'
 
-describe('last types', () => {
-  test('return type with literal argument', () => {
-    expectTypeOf(_.last([])).toBeUndefined()
-    expectTypeOf(_.last([1, 2, 3])).toBeNumber()
+describe('last', () => {
+  test('inlined array', () => {
+    expectTypeOf(_.last([])).toEqualTypeOf<undefined>()
+    expectTypeOf(_.last([1, 2, 3])).toEqualTypeOf<3>()
   })
-  test('return type with mutable variable', () => {
-    const neverList: never[] = []
-    const emptyList: number[] = []
-    const filledList = [1, 2, 3]
 
-    expectTypeOf(_.last(neverList)).toEqualTypeOf<undefined>()
-    expectTypeOf(_.last(emptyList)).toEqualTypeOf<number | undefined>()
-    expectTypeOf(_.last(filledList)).toEqualTypeOf<number | undefined>()
+  test('variable with empty array', () => {
+    const emptyArray = [] as never[]
+
+    expectTypeOf(_.last(emptyArray)).toEqualTypeOf<undefined>()
   })
-  test('return type with immutable variable', () => {
-    const neverList: never[] = [] as const
-    const emptyList: number[] = [] as const
-    const filledList = [1, 2, 3] as const
 
-    expectTypeOf(_.last(neverList)).toBeUndefined()
-    // FIXME: Can this be narrowed to `undefined`?
-    expectTypeOf(_.last(emptyList)).toEqualTypeOf<number | undefined>()
-    expectTypeOf(_.last(filledList)).toEqualTypeOf<1 | 2 | 3>()
+  test('variable with mutable array', () => {
+    const array = [1, 2, 3]
+
+    expectTypeOf(_.last(array)).toEqualTypeOf<number | undefined>()
   })
-})
 
-describe('last types with default value', () => {
-  test('return type with literal argument', () => {
-    expectTypeOf(_.last([], false)).toBeBoolean()
-    expectTypeOf(_.last([1, 2, 3], false)).toBeNumber()
+  test('variable with readonly tuple', () => {
+    const emptyTuple = [] as const
+    const tuple = [1, 2, 3] as const
+
+    expectTypeOf(_.last(emptyTuple)).toEqualTypeOf<undefined>()
+    expectTypeOf(_.last(tuple)).toEqualTypeOf<3>()
   })
-  test('return type with mutable variable', () => {
-    const neverList: never[] = []
-    const emptyList: number[] = []
-    const filledList = [1, 2, 3]
 
-    expectTypeOf(_.last(neverList, false)).toEqualTypeOf<boolean>()
-    expectTypeOf(_.last(emptyList, false)).toEqualTypeOf<number | boolean>()
-    expectTypeOf(_.last(filledList, false)).toEqualTypeOf<number | boolean>()
-  })
-  test('return type with immutable variable', () => {
-    const neverList: never[] = [] as const
-    const emptyList: number[] = [] as const
-    const filledList = [1, 2, 3] as const
+  test('with default value', () => {
+    const emptyArray = [] as never[]
+    const emptyTuple = [] as const
+    const array = [1, 2, 3]
+    const tuple = [1, 2, 3] as const
 
-    expectTypeOf(_.last(neverList, false)).toBeBoolean()
-    // FIXME: Can this be narrowed to `boolean`?
-    expectTypeOf(_.last(emptyList, false)).toEqualTypeOf<number | boolean>()
-    expectTypeOf(_.last(filledList, false)).toEqualTypeOf<1 | 2 | 3>()
+    expectTypeOf(_.last(emptyArray, false)).toEqualTypeOf<false>()
+    expectTypeOf(_.last(emptyTuple, false)).toEqualTypeOf<false>()
+    expectTypeOf(_.last(array, false)).toEqualTypeOf<number | false>()
+    expectTypeOf(_.last(tuple, false)).toEqualTypeOf<3>()
   })
 })

--- a/tests/array/last.test-d.ts
+++ b/tests/array/last.test-d.ts
@@ -1,0 +1,54 @@
+import * as _ from 'radashi'
+import { expectTypeOf } from 'vitest'
+
+describe('last types', () => {
+  test('return type with literal argument', () => {
+    expectTypeOf(_.last([])).toBeUndefined()
+    expectTypeOf(_.last([1, 2, 3])).toBeNumber()
+  })
+  test('return type with mutable variable', () => {
+    const neverList: never[] = []
+    const emptyList: number[] = []
+    const filledList = [1, 2, 3]
+
+    expectTypeOf(_.last(neverList)).toEqualTypeOf<undefined>()
+    expectTypeOf(_.last(emptyList)).toEqualTypeOf<number | undefined>()
+    expectTypeOf(_.last(filledList)).toEqualTypeOf<number | undefined>()
+  })
+  test('return type with immutable variable', () => {
+    const neverList: never[] = [] as const
+    const emptyList: number[] = [] as const
+    const filledList = [1, 2, 3] as const
+
+    expectTypeOf(_.last(neverList)).toBeUndefined()
+    // FIXME: Can this be narrowed to `undefined`?
+    expectTypeOf(_.last(emptyList)).toEqualTypeOf<number | undefined>()
+    expectTypeOf(_.last(filledList)).toEqualTypeOf<1 | 2 | 3>()
+  })
+})
+
+describe('last types with default value', () => {
+  test('return type with literal argument', () => {
+    expectTypeOf(_.last([], false)).toBeBoolean()
+    expectTypeOf(_.last([1, 2, 3], false)).toBeNumber()
+  })
+  test('return type with mutable variable', () => {
+    const neverList: never[] = []
+    const emptyList: number[] = []
+    const filledList = [1, 2, 3]
+
+    expectTypeOf(_.last(neverList, false)).toEqualTypeOf<boolean>()
+    expectTypeOf(_.last(emptyList, false)).toEqualTypeOf<number | boolean>()
+    expectTypeOf(_.last(filledList, false)).toEqualTypeOf<number | boolean>()
+  })
+  test('return type with immutable variable', () => {
+    const neverList: never[] = [] as const
+    const emptyList: number[] = [] as const
+    const filledList = [1, 2, 3] as const
+
+    expectTypeOf(_.last(neverList, false)).toBeBoolean()
+    // FIXME: Can this be narrowed to `boolean`?
+    expectTypeOf(_.last(emptyList, false)).toEqualTypeOf<number | boolean>()
+    expectTypeOf(_.last(filledList, false)).toEqualTypeOf<1 | 2 | 3>()
+  })
+})

--- a/tests/array/last.test-d.ts
+++ b/tests/array/last.test-d.ts
@@ -1,5 +1,4 @@
 import * as _ from 'radashi'
-import { expectTypeOf } from 'vitest'
 
 describe('last types', () => {
   test('return type with literal argument', () => {


### PR DESCRIPTION
## Summary

As with `draw()` in #153, we can narrow the return type for `first()` and `last()` in case the argument is known to be empty or non-empty.

<img width="435" alt="image" src="https://github.com/user-attachments/assets/bd468c18-8033-44e7-ac76-9f04a7f4a476">

With custom `defaultValue`:

<img width="557" alt="image" src="https://github.com/user-attachments/assets/6efc9da9-5b88-4313-bf2e-f29e185a5356">


## Related issue, if any:

- Related: #153
- Previous attempt: #140 

## For any code change,

- [x] Related tests have been added or updated, if needed: Type-level tests added

## Does this PR introduce a breaking change?

No

<!-- This is calculated in Github Actions. -->

_Calculating..._














