### PR TITLE
Fluent API (second attempt)

### DIFF
--- a/src/fluent/index.ts
+++ b/src/fluent/index.ts
@@ -1,0 +1,37 @@
+import { unique } from '../array/unique'
+import { mapValues } from '../object/mapValues'
+
+export const FLUENT = true
+
+declare global {
+  interface Object {
+    mapValues<TValue, TKey extends string | number | symbol, TNewValue>(
+      mapFunc: (value: TValue, key: TKey) => TNewValue
+    ): Record<TKey, TNewValue>
+  }
+
+  interface Array<T> {
+    unique<K extends string | number | symbol = string>(
+      this: T[],
+      toKey?: (item: T) => K
+    ): T[]
+  }
+}
+
+Object.prototype.mapValues = function <
+  TValue,
+  TKey extends string | number | symbol,
+  TNewValue
+>(
+  this: Record<TKey, TValue>,
+  mapFunc: (value: TValue, key: TKey) => TNewValue
+): Record<TKey, TNewValue> {
+  return mapValues(this, mapFunc)
+}
+
+Array.prototype.unique = function <
+  T,
+  K extends string | number | symbol = string
+>(toKey?: (this: T[], item: T) => K): T[] {
+  return unique(this, toKey)
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -131,3 +131,4 @@ export * from './typed/isWeakMap.ts'
 export * from './typed/isWeakSet.ts'
 
 export * from './types'
+export * from './fluent'

--- a/tests/fluent/array.test.ts
+++ b/tests/fluent/array.test.ts
@@ -1,0 +1,9 @@
+import '../../fluent'
+
+describe('fluent unique function', () => {
+  test('correctly removed duplicate items', () => {
+    const list = [1, 1, 2]
+    const result = list.unique()
+    expect(result).toEqual([1, 2])
+  })
+})

--- a/tests/fluent/object.test.ts
+++ b/tests/fluent/object.test.ts
@@ -1,0 +1,15 @@
+import '../../fluent'
+
+describe('mapValues function', () => {
+  test('runs all values against mapper function', () => {
+    const prefixWith = (prefix: string) => (str: string) => `${prefix}${str}`
+    const result = {
+      x: 'hi',
+      y: 'bye'
+    }.mapValues(prefixWith('x'))
+    expect(result).toEqual({
+      x: 'xhi',
+      y: 'xbye'
+    })
+  })
+})


### PR DESCRIPTION
## Summary

As discussed in PR#131, a first example of fluent interface for mapValues and unique functions.
Haven't beem able to exclude usage to when radashi/fluent is imported though. Lacking the knowledge for that, unfortunately. Maybe someone can help there

## Related issue, if any:

None

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No

## Bundle impact

| Status | File | Size |
|---|---|---|

[^1337]: Function size includes the `import` dependencies of the function.

