### PR TITLE
chore: deprecate `flat`

### DIFF
--- a/docs/array/flat.mdx
+++ b/docs/array/flat.mdx
@@ -1,7 +1,13 @@
 ---
-title: flat (deprecated)
+title: flat
 description: Flatten an array of arrays into a single dimension
 ---
+
+:::caution[Deprecated]
+This function is deprecated. Use `Array.prototype.flat` instead, which is widely available and supports both deep and shallow flattening.
+
+[MDN: Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
+:::
 
 ### Usage
 
@@ -16,9 +22,3 @@ _.flat(gods) // => [ra, loki, zeus]
 ```
 
 Note, `_.flat` is not recursive and will not flatten children of children of children ... of children. It will only flatten `T[][]` an array of arrays.
-
-:::caution
-The `_.flat` function has been deprecated and will be removed in the next major release. Please use `Array.prototype.flat` which is widely available and supports both deep and shallow flattening.
-
-[MDN Documentation for Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
-:::

--- a/docs/array/flat.mdx
+++ b/docs/array/flat.mdx
@@ -1,5 +1,5 @@
 ---
-title: flat
+title: flat (deprecated)
 description: Flatten an array of arrays into a single dimension
 ---
 
@@ -16,3 +16,9 @@ _.flat(gods) // => [ra, loki, zeus]
 ```
 
 Note, `_.flat` is not recursive and will not flatten children of children of children ... of children. It will only flatten `T[][]` an array of arrays.
+
+:::caution
+The `_.flat` function has been deprecated and will be removed in the next major release. Please use `Array.prototype.flat` which is widely available and supports both deep and shallow flattening.
+
+[MDN Documentation for Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)
+:::

--- a/src/array/flat.ts
+++ b/src/array/flat.ts
@@ -2,14 +2,14 @@
  * Given an array of arrays, returns a single dimensional array with
  * all items in it.
  *
+ * @deprecated Use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) instead.
+ *
  * @see https://radashi-org.github.io/reference/array/flat
  * @example
  * ```ts
  * flat([[1, 2], [[3], 4], [5]])
  * // [1, 2, [3], 4, 5]
  * ```
- *
- * @deprecated Use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) instead.
  */
 export function flat<T>(lists: readonly T[][]): T[] {
   return lists.flat()

--- a/src/array/flat.ts
+++ b/src/array/flat.ts
@@ -8,6 +8,8 @@
  * flat([[1, 2], [[3], 4], [5]])
  * // [1, 2, [3], 4, 5]
  * ```
+ *
+ * @deprecated - use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) insted
  */
 export function flat<T>(lists: readonly T[][]): T[] {
   return lists.reduce((acc, list) => {

--- a/src/array/flat.ts
+++ b/src/array/flat.ts
@@ -9,7 +9,7 @@
  * // [1, 2, [3], 4, 5]
  * ```
  *
- * @deprecated - use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) insted
+ * @deprecated Use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) instead.
  */
 export function flat<T>(lists: readonly T[][]): T[] {
   return lists.flat()

--- a/src/array/flat.ts
+++ b/src/array/flat.ts
@@ -12,8 +12,5 @@
  * @deprecated - use [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) insted
  */
 export function flat<T>(lists: readonly T[][]): T[] {
-  return lists.reduce((acc, list) => {
-    acc.push(...list)
-    return acc
-  }, [])
+  return lists.flat()
 }


### PR DESCRIPTION
> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

Update the JSDOC and documentation about the function being deprecated.

## Related issue, if any:

https://github.com/orgs/radashi-org/discussions/84

## For any code change,

- [x] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?
Yes

## Bundle impact

| Status | File | Size  [^1337] | Difference (%) |
|---|---|---|---|
| M | `src/array/flat.ts` | 49 | -28 (-36%) |

[^1337]: Function size includes the `import` dependencies of the function.



