### PR TITLE
chore: generate the umbrella module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 node_modules
-.coverage/
-dist
 coverage
-archive.zip
-archive.tar.gz
-.chiller/
-.next/
+dist
+src/mod.ts

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vitest/coverage-v8": "2.0.3",
     "concurrently": "^8.2.2",
     "eslint-plugin-compat": "^6.0.0",
+    "fast-glob": "^3.3.2",
     "glob": "^11.0.0",
     "prettier": "^3.3.2",
     "prettier-plugin-pkg": "^0.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       eslint-plugin-compat:
         specifier: ^6.0.0
         version: 6.0.0(eslint@8.57.0)
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.2
       glob:
         specifier: ^11.0.0
         version: 11.0.0

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,14 +1,45 @@
+import glob from 'fast-glob'
+import fs from 'node:fs'
+import path from 'node:path'
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: { radashi: 'src/mod.ts' },
-  format: ['cjs', 'esm'],
-  dts: true,
-  target: 'node16',
-  pure: ['Symbol'],
-  treeshake: {
-    preset: 'smallest',
-    propertyReadSideEffects: false,
-    moduleSideEffects: false,
-  },
+export default defineConfig(async () => {
+  await generateEntryPoint()
+  return {
+    entry: { radashi: 'src/mod.ts' },
+    format: ['cjs', 'esm'],
+    dts: true,
+    target: 'node16',
+    pure: ['Symbol'],
+    treeshake: {
+      preset: 'smallest',
+      propertyReadSideEffects: false,
+      moduleSideEffects: false,
+    },
+  }
 })
+
+export async function generateEntryPoint() {
+  let contents = ''
+
+  const files = await glob(['**/*.ts', '!*.ts'], { cwd: 'src' })
+  files.sort()
+  files.push('types.ts')
+
+  let lastDir = ''
+  for (const file of files) {
+    const dir = path.dirname(file)
+    if (dir !== lastDir) {
+      if (lastDir.length) {
+        contents += '\n\n'
+      }
+      lastDir = dir
+    } else if (contents.length) {
+      contents += '\n'
+    }
+
+    contents += `export * from './${file}'`
+  }
+
+  fs.writeFileSync('src/mod.ts', contents + '\n')
+}


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->
## Summary

<!-- Describe what the change does and why it should be merged. -->
When `pnpm build` runs, the `src/mod.ts` module is generated.

- *“Why write to a file instead of using virtual modules?”*
  The JSR.io publishing process expects the `src/mod.ts` file to exist.

### Motivation

More streamlined development cycle. Now you don't need to manually add an export for your new function.

### To Do

- [ ] Make this work with `pnpm dev`
- [ ] Make this work with `pnpm test`
