### PR TITLE
fix(toggle): use -1 as index for `toKey()` with toggled `item`

### DIFF
--- a/docs/array/toggle.mdx
+++ b/docs/array/toggle.mdx
@@ -16,7 +16,7 @@ _.toggle(gods, 'ra') // => ['zeus', 'loki']
 _.toggle(gods, 'vishnu') // => ['ra', 'zeus', 'loki', 'vishnu']
 ```
 
-### toggle(list, item, identity)
+### toggle(list, item, toKey)
 
 You can pass an optional `toKey` function to determine the identity of non-primitive values. Helpful when working with more complex data types.
 
@@ -34,7 +34,7 @@ _.toggle(gods, ra, g => g.name) // => [zeus, loki]
 _.toggle(gods, vishnu, g => g.name) // => [ra, zeus, loki, vishnu]
 ```
 
-### toggle(list, item, identity, options)
+### toggle(list, item, toKey, options)
 
 By default, toggle will append the item if it does not exist. If you need to prepend the item instead you can override the `strategy` in the options argument.
 

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -1,6 +1,19 @@
 /**
- * If the item matching the condition already exists in the list it
- * will be removed. If it does not it will be added.
+ * Either adds or removes an item from an array, based on whether it
+ * already exists in the array. If multiple items match the given
+ * `item`, all matching items will be removed.
+ *
+ * Note that the given `array` is *not mutated*. A copy of the array
+ * is returned with the given item either added or removed.
+ *
+ * - **"toKey" parameter**
+ *   - You may define a `toKey` callback, which is a function that
+ *   converts an item into a value that can be checked for equality.
+ *   When called with the given `item`, an index of -1 will be passed.
+ *
+ * - **"strategy" option**
+ *   - You may define a `strategy` option, which determines where the
+ *   item should be added in the array.
  *
  * @see https://radashi-org.github.io/reference/array/toggle
  * @example
@@ -23,11 +36,7 @@
 export function toggle<T>(
   array: readonly T[],
   item: T,
-  /**
-   * Converts an item of type T item into a value that can be checked
-   * for equality. For an item idx will be -1.
-   */
-  toKey?: null | ((item: T, idx: number) => number | string | symbol),
+  toKey?: ((item: T, idx: number) => number | string | symbol) | null,
   options?: {
     strategy?: 'prepend' | 'append'
   },

--- a/src/array/toggle.ts
+++ b/src/array/toggle.ts
@@ -25,7 +25,7 @@ export function toggle<T>(
   item: T,
   /**
    * Converts an item of type T item into a value that can be checked
-   * for equality
+   * for equality. For an item idx will be -1.
    */
   toKey?: null | ((item: T, idx: number) => number | string | symbol),
   options?: {
@@ -39,9 +39,15 @@ export function toggle<T>(
     return [...array]
   }
 
-  const matcher = toKey
-    ? (x: T, idx: number) => toKey(x, idx) === toKey(item, idx)
-    : (x: T) => x === item
+  let matcher: (item: T, idx: number) => boolean
+
+  if (toKey) {
+    const key = toKey(item, -1)
+
+    matcher = (x: T, idx: number) => toKey(x, idx) === key
+  } else {
+    matcher = (x: T) => x === item
+  }
 
   const existing = array.find(matcher)
 

--- a/tests/array/toggle.test.ts
+++ b/tests/array/toggle.test.ts
@@ -44,4 +44,13 @@ describe('toggle', () => {
 
     expect(_.toggle([1, 2], null)).toEqual([1, 2, null])
   })
+  test('should use idx=-1 for item', () => {
+    const toKey = vi.fn(v => v)
+
+    expect(_.toggle(['a', 'b'], 'c', toKey)).toEqual(['a', 'b', 'c'])
+
+    expect(toKey).toBeCalledWith('c', -1)
+    expect(toKey).toBeCalledWith('a', 0)
+    expect(toKey).toBeCalledWith('b', 1)
+  })
 })


### PR DESCRIPTION
## Summary

It's strange to call `toKey` for an item with different indexes. We can provide `-1` instead and call it only once. 

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->




## Bundle impact

| Status | File | Size | Difference (%) |
|---|---|---|---|
| M | `src/array/toggle.ts` | 257 [^1337] | +22 (+9%) |

[^1337]: Function size includes the `import` dependencies of the function.



