### PR TITLE
chore(fix): allow Result tuple to be `[undefined, undefined]`

### DIFF
--- a/docs/typed/isResult.mdx
+++ b/docs/typed/isResult.mdx
@@ -40,8 +40,6 @@ Also see the related [isResultOk](/typed/isResultOk) and [isResultErr](/typed/is
 - The second element is always the **result value**, unless an error occurred.
 - These tuples are represented by the `Result<TResult, TError>` type.
 - A default error type of `Error` is used when no error type is explicitly defined (e.g. `Result<string>`).
-- The default error type is _not_ `unknown` because we assume you're following best practices and so you avoid throwing anything but `Error` objects.
-- You're free to define the error type to be anything (like `Result<string, Error | number>`), not just `Error` types.
 
 ### Ok and Err
 
@@ -55,6 +53,8 @@ The names "Ok" and "Err" are inspired by Rust's `std::result` module.
 To check for an `Ok` result, do this:
 
 ```ts
+declare const value: unknown
+
 if (isResult(value) && value[0] == null) {
   value // <-- now an Ok<unknown> type
   value[1] // <-- This is the resulting value!
@@ -64,6 +64,8 @@ if (isResult(value) && value[0] == null) {
 To check for an `Err` result, do this:
 
 ```ts
+declare const value: unknown
+
 if (isResult(value) && value[0] != null) {
   value // <-- now an Err<Error> type
   value[0] // <-- This is the error!

--- a/docs/typed/isResult.mdx
+++ b/docs/typed/isResult.mdx
@@ -15,10 +15,6 @@ import * as _ from 'radashi'
 _.isResult([undefined, 42]) // => true
 _.isResult([new Error(), undefined]) // => true
 
-// Result tuples cannot have both a value and an error, or neither.
-_.isResult([undefined, undefined]) // => false
-_.isResult([new Error(), true]) // => false
-
 // Tuple must be of length 2.
 _.isResult([new Error()]) // => false
 _.isResult([undefined, true, undefined]) // => false
@@ -27,6 +23,9 @@ _.isResult([undefined, true, undefined]) // => false
 _.isResult([]) // => false
 _.isResult({}) // => false
 _.isResult(null) // => false
+
+// Result tuples cannot have both a value and an error.
+_.isResult([new Error(), true]) // => false
 ```
 
 Also see the related [isResultOk](/typed/isResultOk) and [isResultErr](/typed/isResultErr) functions.
@@ -38,7 +37,7 @@ Also see the related [isResultOk](/typed/isResultOk) and [isResultErr](/typed/is
 “Results” are tuples of 2 elements (an **error** and a **result value**).
 
 - The first element is always the **error**, or `undefined` if the operation was successful.
-- The second element is always the **result value**, or `undefined` if the operation failed.
+- The second element is always the **result value**, unless an error occurred.
 - These tuples are represented by the `Result<TResult, TError>` type.
 - A default error type of `Error` is used when no error type is explicitly defined (e.g. `Result<string>`).
 - The default error type is _not_ `unknown` because we assume you're following best practices and so you avoid throwing anything but `Error` objects.
@@ -70,3 +69,5 @@ if (isResult(value) && value[0] != null) {
   value[0] // <-- This is the error!
 }
 ```
+
+You can also use the `isResultOk` and `isResultErr` functions to check for `Ok` and `Err` results respectively.

--- a/src/typed/isResult.ts
+++ b/src/typed/isResult.ts
@@ -22,7 +22,7 @@ import { isArray, isError, type Result } from 'radashi'
  * isResult([new Error(), true]) => false
  * ```
  */
-export function isResult(value: unknown): value is Result<unknown, unknown> {
+export function isResult(value: unknown): value is Result<unknown> {
   return (
     isArray(value) &&
     value.length === 2 &&

--- a/src/typed/isResult.ts
+++ b/src/typed/isResult.ts
@@ -1,4 +1,4 @@
-import { isArray, type Result } from 'radashi'
+import { isArray, isError, type Result } from 'radashi'
 
 /**
  * Returns true if the value is a `Result` tuple.
@@ -9,10 +9,6 @@ import { isArray, type Result } from 'radashi'
  * isResult([undefined, 42]) => true
  * isResult([new Error(), undefined]) => true
  *
- * // Result tuples cannot have both a value and an error, or neither.
- * isResult([undefined, undefined]) => false
- * isResult([new Error(), true]) => false
- *
  * // Tuple must be of length 2.
  * isResult([new Error()]) => false
  * isResult([undefined, true, undefined]) => false
@@ -21,12 +17,15 @@ import { isArray, type Result } from 'radashi'
  * isResult([]) => false
  * isResult({}) => false
  * isResult(null) => false
+ *
+ * // Result tuples cannot have both a value and an error.
+ * isResult([new Error(), true]) => false
  * ```
  */
 export function isResult(value: unknown): value is Result<unknown, unknown> {
   return (
     isArray(value) &&
     value.length === 2 &&
-    (value[0] === undefined) !== (value[1] === undefined)
+    (isError(value[0]) ? value[1] : value[0]) === undefined
   )
 }

--- a/src/typed/isResultErr.ts
+++ b/src/typed/isResultErr.ts
@@ -10,7 +10,7 @@ import { type Err, isResult } from 'radashi'
  * isResultErr([undefined, "hello"]) // false
  * ```
  */
-export function isResultErr<TError = Error>(
+export function isResultErr<TError extends Error = Error>(
   value: unknown,
 ): value is Err<TError> {
   return isResult(value) && value[0] !== undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,7 +123,7 @@ export type Ok<TResult> = [err: undefined, result: TResult]
  * //   ^? [TypeError | MyCoolCustomError, undefined]
  * ```
  */
-export type Err<TError = Error> = [err: NonNullable<TError>, result: undefined]
+export type Err<TError extends Error = Error> = [err: TError, result: undefined]
 
 /**
  * A result tuple.
@@ -139,9 +139,9 @@ export type Err<TError = Error> = [err: NonNullable<TError>, result: undefined]
  * //   ^? Ok<string> | Err<TypeError>
  * ```
  */
-export type Result<TResult, TError = Error> =
+export type Result<TResult, TError extends Error = Error> =
   | Ok<TResult>
-  | Err<NonNullable<TError>>
+  | Err<TError>
 
 /**
  * A promise that resolves to a result tuple.
@@ -155,12 +155,12 @@ export type Result<TResult, TError = Error> =
  * //   ^? Promise<Ok<string> | Err<TypeError>>
  * ```
  */
-export type ResultPromise<TResult, TError = Error> = Promise<
-  [NonNullable<TError>] extends [never]
+export type ResultPromise<TResult, TError extends Error = Error> = Promise<
+  [TError] extends [never]
     ? Ok<TResult>
     : [TResult] extends [never]
-      ? Err<NonNullable<TError>>
-      : Result<TResult, NonNullable<TError>>
+      ? Err<TError>
+      : Result<TResult, TError>
 >
 
 /**

--- a/tests/typed/isResult.test.ts
+++ b/tests/typed/isResult.test.ts
@@ -4,10 +4,10 @@ describe('isResult', () => {
   test('should return true for valid Result tuples', () => {
     expect(_.isResult([undefined, 42])).toBe(true)
     expect(_.isResult([new Error(), undefined])).toBe(true)
+    expect(_.isResult([undefined, undefined])).toBe(true)
   })
 
   test('should return false for invalid Result tuples', () => {
-    expect(_.isResult([undefined, undefined])).toBe(false)
     expect(_.isResult([new Error(), true])).toBe(false)
     expect(_.isResult([new Error()])).toBe(false)
     expect(_.isResult([undefined, true, undefined])).toBe(false)

--- a/tests/typed/isResult.test.ts
+++ b/tests/typed/isResult.test.ts
@@ -4,6 +4,7 @@ describe('isResult', () => {
   test('should return true for valid Result tuples', () => {
     expect(_.isResult([undefined, 42])).toBe(true)
     expect(_.isResult([new Error(), undefined])).toBe(true)
+    expect(_.isResult([new TypeError(), undefined])).toBe(true)
     expect(_.isResult([undefined, undefined])).toBe(true)
   })
 


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Fix `isResult` to return true for a `[undefined, undefined]` tuple. This is to handle the case where a function with a possibly undefined return value is wrapped with `tryit`, which may produce such a tuple.

I'm also constraining the `TError` type parameter of Result/Ok/Err so it must be a subtype of the built-in `Error` type. In other words, it no longer allows the error element to be any type. This is necessary to reduce the chance of `isResult` returning a false positive for certain arrays.

*Note: This is a "chore" and not a "fix" because `isResult` hasn't been released yet.*

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size  [^1337] | Difference (%) |
|---|---|---|---|
| M | `src/typed/isResult.ts` | 217 | +102 (+89%) |
| M | `src/typed/isResultErr.ts` | 261 | +102 (+64%) |

[^1337]: Function size includes the `import` dependencies of the function.



