### PR TITLE
ci: replace deprecated set-output commands with new syntaxes

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,9 +25,9 @@ jobs:
           bash scripts/checkout-pr.sh src benchmarks
 
           if [ -z "$(git status --porcelain)" ]; then
-            echo '::set-output name=has_changes::false'
+            echo 'has_changes=false' >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=has_changes::true'
+            echo 'has_changes=true' >> $GITHUB_OUTPUT
           fi
 
       - name: Install pnpm

--- a/.github/workflows/bundle-impact.yml
+++ b/.github/workflows/bundle-impact.yml
@@ -24,9 +24,9 @@ jobs:
           git checkout "pr/$PR_HEAD_REF" -- src
 
           if [ -z "$(git status --porcelain)" ]; then
-            echo '::set-output name=has_changes::false'
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=has_changes::true'
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Install pnpm

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Calculate version
         id: get-version
-        run: echo "::set-output name=version::$(node -p "require('./package.json').version")-pr${{ github.event.issue.number }}.$(git rev-parse --short HEAD)"
+        run: echo "version=$(node -p \"require('./package.json').version\")-pr${{ github.event.issue.number }}.$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Update package version
         run: npm version ${{ steps.get-version.outputs.version }} --no-git-tag-version

--- a/.github/workflows/register-pr.yml
+++ b/.github/workflows/register-pr.yml
@@ -23,9 +23,9 @@ jobs:
           bash scripts/checkout-pr.sh src docs
 
           if [ -n "$(git status --porcelain src | grep '^A')" ]; then
-            echo '::set-output name=has_new_func::true'
+            echo "has_new_func=true" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=has_new_func::false'
+            echo "has_new_func=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Wait for other checks to finish


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary
Recently, I have seen [this warning error in CI](https://github.com/radashi-org/radashi/actions/runs/10517795947/job/29142568729?pr=214). 
![image](https://github.com/user-attachments/assets/0e663a81-a33a-4b19-9764-f1cd8421e7d1)

So I opened this pull request, updates the GitHub Actions workflow to replace the deprecated set-output commands with the new recommended syntax. 

> [!NOTE]
> documentation https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
