### PR TITLE
fix(types): avoid inferring `memo` return type from `key` option

### DIFF
--- a/src/curry/memo.ts
+++ b/src/curry/memo.ts
@@ -1,3 +1,5 @@
+import type { NoInfer } from 'radashi'
+
 type Cache<T> = Record<string, { exp: number | null; value: T }>
 
 function memoize<TArgs extends any[], TResult>(
@@ -56,7 +58,7 @@ export interface MemoOptions<TArgs extends any[]> {
  */
 export function memo<TArgs extends any[], TResult>(
   func: (...args: TArgs) => TResult,
-  options: MemoOptions<TArgs> = {},
+  options: MemoOptions<NoInfer<TArgs>> = {},
 ): (...args: TArgs) => TResult {
   return memoize({}, func, options.key ?? null, options.ttl ?? null)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export type SwitchAny<T, U> = [T] extends [Any] ? U : T
 export type SwitchNever<T, U> = [T] extends [never] ? U : T
 
 /**
+ * Prevent type inference on type `T`.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/14829#issuecomment-504042546
+ */
+export type NoInfer<T> = [T][T extends any ? 0 : never]
+
+/**
  * Extract types in `T` that are assignable to `U`. Coerce `any` and
  * `never` types to unknown.
  */

--- a/tests/curry/memo.test-d.ts
+++ b/tests/curry/memo.test-d.ts
@@ -1,0 +1,18 @@
+import * as _ from 'radashi'
+
+describe('memo return type', () => {
+  test('memo with single argument key function', () => {
+    const foo = _.memo((a: string, b?: string) => {}, { key: a => a })
+    expectTypeOf(foo).toEqualTypeOf<
+      (a: string, b?: string | undefined) => void
+    >()
+  })
+
+  test('memo with two argument key function', () => {
+    const foo = _.memo((a: string, b?: string) => {}, { key: (a, b) => a })
+    expectTypeOf(foo).toEqualTypeOf<
+      (a: string, b?: string | undefined) => void
+    >()
+    foo('a')
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Avoid inferring the `memo` return type from any of the given options, like the `key` callback.

See the added type tests for two examples.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Closes #230

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related tests have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


