### PR TITLE
feat(parallel): clamp the limit between 1 and array length

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -37,3 +37,7 @@ https://github.com/radashi-org/radashi/pull/262
 #### Add `signal` option to `parallel`
 
 https://github.com/radashi-org/radashi/pull/262
+
+#### Tolerate out-of-range `parallel` limit
+
+https://github.com/radashi-org/radashi/pull/238

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -20,6 +20,8 @@ const users = await _.parallel(3, userIds, async userId => {
 })
 ```
 
+If the limit is greater than the array length, it will be clamped to the array length. Similarly, if the limit is less than 1, it will be clamped to 1.
+
 ### Interrupting
 
 Since v12.3.0, processing can be manually interrupted. Pass an `AbortController.signal` via the `signal` option. When the signal is aborted, no more calls to your callback will be made. Any in-progress calls will continue to completion, unless you manually connect the signal inside your callback. In other words, `parallel` is only responsible for aborting the array loop, not the async operations themselves.

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -20,7 +20,7 @@ const users = await _.parallel(3, userIds, async userId => {
 })
 ```
 
-If the limit is greater than the array length, it will be clamped to the array length. Similarly, if the limit is less than 1, it will be clamped to 1.
+Since v12.3.0, if the limit is greater than the array length, it will be clamped to the array length. Similarly, if the limit is less than 1, it will be clamped to 1.
 
 ### Interrupting
 

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -1,5 +1,6 @@
 import {
   AggregateError,
+  clamp,
   flat,
   fork,
   isNumber,
@@ -99,7 +100,7 @@ export async function parallel<T, K>(
   }
 
   const queues = Promise.all(
-    list(1, Math.min(Math.max(options.limit, 1), array.length)).map(
+    list(1, clamp(options.limit, 1, array.length)).map(
       () => new Promise(processor),
     ),
   )

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -25,8 +25,9 @@ type WorkItemResult<K> = {
 export type ParallelOptions = {
   /**
    * The maximum number of functions to run concurrently. If a
-   * negative number is passed, only one function will run at a
-   * time.
+   * negative number is passed, only one function will run at a time.
+   * If a number bigger than the array `length` is passed, the array
+   * length will be used.
    */
   limit: number
   signal?: AbortSignal
@@ -98,7 +99,9 @@ export async function parallel<T, K>(
   }
 
   const queues = Promise.all(
-    list(1, Math.max(1, options.limit)).map(() => new Promise(processor)),
+    list(1, Math.min(Math.max(options.limit, 1), array.length)).map(
+      () => new Promise(processor),
+    ),
   )
 
   let signalPromise: Promise<never> | undefined

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -22,12 +22,15 @@ type WorkItemResult<K> = {
   error: any
 }
 
-export type ParallelOptions =
-  | {
-      limit: number
-      signal?: AbortSignal
-    }
-  | number
+export type ParallelOptions = {
+  /**
+   * The maximum number of functions to run concurrently. If a
+   * negative number is passed, only one function will run at a
+   * time.
+   */
+  limit: number
+  signal?: AbortSignal
+}
 
 /**
  * Executes many async functions in parallel. Returns the results from
@@ -57,7 +60,7 @@ export type ParallelOptions =
  * @version 12.1.0
  */
 export async function parallel<T, K>(
-  options: ParallelOptions,
+  options: ParallelOptions | number,
   array: readonly T[],
   func: (item: T) => Promise<K>,
 ): Promise<K[]> {
@@ -95,7 +98,7 @@ export async function parallel<T, K>(
   }
 
   const queues = Promise.all(
-    list(1, options.limit).map(() => new Promise(processor)),
+    list(1, Math.max(1, options.limit)).map(() => new Promise(processor)),
   )
 
   let signalPromise: Promise<never> | undefined

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -140,4 +140,17 @@ describe('parallel', () => {
     expect(Math.max(...tracking)).toBe(1)
     expect(tracking).toEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
   })
+
+  test('should run the same number of parallel functions as the array size when Infinity is passed', async () => {
+    let numInProgress = 0
+    const tracking: number[] = []
+    await _.parallel(Number.POSITIVE_INFINITY, _.list(1, 10), async () => {
+      numInProgress++
+      tracking.push(numInProgress)
+      await _.sleep(0)
+      numInProgress--
+    })
+    expect(Math.max(...tracking)).toBe(10)
+    expect(tracking).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
 })

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -88,8 +88,6 @@ describe('parallel', () => {
   })
 
   test('remove abort listener after completion', async () => {
-    vi.useFakeTimers()
-
     const ctrl = new AbortController()
     const removeEventListener = vi.spyOn(ctrl.signal, 'removeEventListener')
 
@@ -108,5 +106,25 @@ describe('parallel', () => {
       'abort',
       expect.any(Function),
     )
+  })
+
+  test('limit defaults to 1 if negative', async () => {
+    vi.useFakeTimers()
+
+    let numInProgress = 0
+    const tracking: number[] = []
+
+    const promise = _.parallel(-1, _.list(1, 5), async () => {
+      numInProgress++
+      tracking.push(numInProgress)
+      await _.sleep(10)
+      numInProgress--
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    await promise
+
+    expect(Math.max(...tracking)).toBe(1)
+    expect(tracking).toEqual([1, 1, 1, 1, 1])
   })
 })

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -127,4 +127,17 @@ describe('parallel', () => {
     expect(Math.max(...tracking)).toBe(1)
     expect(tracking).toEqual([1, 1, 1, 1, 1])
   })
+
+  test('should run only one parallel function when 0 is passed', async () => {
+    let numInProgress = 0
+    const tracking: number[] = []
+    await _.parallel(0, _.list(1, 10), async () => {
+      numInProgress++
+      tracking.push(numInProgress)
+      await _.sleep(0)
+      numInProgress--
+    })
+    expect(Math.max(...tracking)).toBe(1)
+    expect(tracking).toEqual([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+  })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

now: 
```ts 
const array = [1, 2, 3]
const doSomething = async (n: number) => { ...}
_.parallel(-1, array, doSomething) // run 1 function in paraller (in the current implementation no function is executed)
_.parallel(0, array, doSomething) // run 1 function in paraller (in the current implementation no function is executed)
_.parallel(100, array, doSomething) // run 3 function in paraller 
_.parallel(Infinity, array, doSomething) // run 3 function in paraller (in the current implementation this throws an error)
```

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
https://github.com/orgs/radashi-org/discussions/235
https://github.com/sodiray/radash/issues/426

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/parallel.ts` | 1698 | +135 (+9%) |

[^1337]: Function size includes the `import` dependencies of the function.



