### PR TITLE
chore: make merge function work faster with large arrays

### DIFF
--- a/benchmarks/array/merge.bench.ts
+++ b/benchmarks/array/merge.bench.ts
@@ -18,4 +18,17 @@ describe('merge', () => {
     ]
     _.merge(inputA, inputB, x => x.name)
   })
+
+  bench('with long arrays', () => {
+    const inputA = Array.from({ length: 10_000 }, (_, i) => ({
+      name: `a-${i}`,
+      id: i,
+    }))
+    const inputB = Array.from({ length: 10_000 }, (_, i) => ({
+      name: `b-${i}`,
+      id: i,
+    }))
+
+    _.merge(inputA, inputB, x => x.id)
+  })
 })

--- a/src/array/merge.ts
+++ b/src/array/merge.ts
@@ -31,9 +31,10 @@ export function merge<T>(
   if (!toKey) {
     return [...prev]
   }
-  const keys = array.map(toKey)
+  const keys = new Map(array.map(v => [toKey(v), v]))
   return prev.map(prevItem => {
-    const index = keys.indexOf(toKey(prevItem))
-    return index > -1 ? array[index] : prevItem
+    const key = toKey(prevItem)
+
+    return keys.has(key) ? keys.get(key)! : prevItem
   })
 }

--- a/src/array/merge.ts
+++ b/src/array/merge.ts
@@ -31,7 +31,12 @@ export function merge<T>(
   if (!toKey) {
     return [...prev]
   }
-  const keys = new Map(array.map(v => [toKey(v), v]))
+  const keys = new Map()
+
+  for (const val of array) {
+    keys.set(toKey(val), val)
+  }
+
   return prev.map(prevItem => {
     const key = toKey(prevItem)
 

--- a/src/array/merge.ts
+++ b/src/array/merge.ts
@@ -32,14 +32,11 @@ export function merge<T>(
     return [...prev]
   }
   const keys = new Map()
-
-  for (const val of array) {
-    keys.set(toKey(val), val)
+  for (const item of array) {
+    keys.set(toKey(item), item)
   }
-
   return prev.map(prevItem => {
     const key = toKey(prevItem)
-
     return keys.has(key) ? keys.get(key)! : prevItem
   })
 }


### PR DESCRIPTION
## Summary

Changed the `array.indexOf` to Map to get rid of the nested loop and make the function work faster with large arrays. The function performs a slight worse for the small arrays, but the difference is negligible. With a big arrays it's significantly faster. The benchmark shows that for arrays with 10000 elements the new implementation is 10 times faster.


- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?
No



## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/merge.ts` | 210 | +25 (+14%) |

[^1337]: Function size includes the `import` dependencies of the function.



