### PR TITLE
fix(isNumber)!: return true for NaN values

### DIFF
--- a/.github/next-major.md
+++ b/.github/next-major.md
@@ -37,3 +37,18 @@ The `####` headline should be short and descriptive of the breaking change. In t
   const func = debounce({ delay: 1000 }, mockFunc)
   expect(func.callee).toBe(mockFunc)
   ```
+
+#### Change `isNumber` to return true for `NaN` values
+
+Returning true for NaN values allows `isNumber` to perform “type narrowing” in TypeScript without risking a runtime error. This is because NaN is not a valid type in TypeScript, so it cannot be separated from other numbers.
+
+```ts
+const value: number | string = NaN
+
+if (!isNumber(value)) {
+  // Would previously have caused a runtime error, because `isNumber` returned false for `NaN`
+  value.toUpperCase()
+}
+
+isNumber(NaN) // => true
+```

--- a/docs/typed/isNumber.mdx
+++ b/docs/typed/isNumber.mdx
@@ -14,4 +14,5 @@ import * as _ from 'radashi'
 _.isNumber('hello') // => false
 _.isNumber(['hello']) // => false
 _.isNumber(12) // => true
+_.isNumber(NaN) // => true
 ```

--- a/src/typed/isFloat.ts
+++ b/src/typed/isFloat.ts
@@ -12,5 +12,5 @@ import { isNumber } from 'radashi'
  * @version 12.1.0
  */
 export function isFloat(value: any): value is number {
-  return isNumber(value) && value % 1 !== 0
+  return isNumber(value) && !Number.isNaN(value) && value % 1 !== 0
 }

--- a/src/typed/isNumber.ts
+++ b/src/typed/isNumber.ts
@@ -6,10 +6,10 @@
  * ```ts
  * isNumber(0) // => true
  * isNumber('0') // => false
- * isNumber(NaN) // => false
+ * isNumber(NaN) // => true
  * ```
  * @version 12.1.0
  */
 export function isNumber(value: unknown): value is number {
-  return typeof value === 'number' && !Number.isNaN(value)
+  return typeof value === 'number'
 }

--- a/tests/typed/isNumber.test.ts
+++ b/tests/typed/isNumber.test.ts
@@ -26,9 +26,9 @@ describe('isNumber', () => {
     const result = _.isNumber(22.0567)
     expect(result).toBeTruthy()
   })
-  test('returns false for NaN', () => {
+  test('returns true for NaN', () => {
     const result = _.isNumber(Number.NaN)
-    expect(result).toBeFalsy()
+    expect(result).toBeTruthy()
   })
   test('returns false for array', () => {
     const result = _.isNumber([1, 2, 3])


### PR DESCRIPTION
<!--
Please write in English.
Please follow the template, all sections are required.
Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

This PR updates the `isNumber` function to return true for `NaN` values, Resolve #74 

## Related issue, if any:

https://github.com/sodiray/radash/issues/405
https://github.com/orgs/radashi-org/discussions/74

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

Yes


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/curry/debounce.ts` | 257 | +9 (+4%) |
| M | `src/typed/isNumber.ts` | 63 | -18 (-22%) |

[^1337]: Function size includes the `import` dependencies of the function.



