### PR TITLE
feat: add `signal` option to `retry` and `parallel`

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -8,4 +8,5 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Features
 
-####
+#### Add `AbortSignal` options to retry and parallel 
+https://github.com/radashi-org/radashi/pull/262

--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -8,5 +8,10 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Features
 
-#### Add `AbortSignal` options to retry and parallel 
+#### Add `signal` option to `retry`
+
+https://github.com/radashi-org/radashi/pull/262
+
+#### Add `signal` option to `parallel`
+
 https://github.com/radashi-org/radashi/pull/262

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -1,18 +1,12 @@
 ---
 title: parallel
-description: Run many async function in parallel
+description: Parallelize async operations while managing load
 since: 12.1.0
 ---
 
 ### Usage
 
-Like `_.map` but built specifically to run the async callback functions
-in parallel. The first argument is a limit of how many functions should
-be allowed to run at once.
-
-Optionally, you can pass `AbortController.signal` as the last parameter to abort the operation if needed.
-
-Returns an array of results.
+The `parallel` function processes an array with an async callback. The first argument controls how many array items are processed at one time. Similar to `Promise.all`, an ordered array of results is returned.
 
 ```ts
 import * as _ from 'radashi'
@@ -26,11 +20,34 @@ const users = await _.parallel(3, userIds, async userId => {
 })
 ```
 
-### Errors
+### Interrupting
 
-When all work is complete parallel will check for errors. If any
-occurred they will all be thrown in a single `AggregateError` that
-has an `errors` property that is all the errors that were thrown.
+Processing can be manually interrupted. Pass an `AbortController.signal` via the `signal` option. When the signal is aborted, no more calls to your callback will be made. Any in-progress calls will continue to completion, unless you manually connect the signal inside your callback. In other words, `parallel` is only responsible for aborting the array loop, not the async operations themselves.
+
+When `parallel` is interrupted by the signal, it throws a `DOMException` (even in Node.js) with the message `This operation was aborted` and name `AbortError`.
+
+```ts
+import * as _ from 'radashi'
+
+const abortController = new AbortController()
+const signal = abortController.signal
+
+// Pass in the signal:
+const pizzas = await _.parallel(
+  { limit: 2, signal },
+  ['pepperoni', 'cheese', 'mushroom'],
+  async topping => {
+    return await bakePizzaInWoodFiredOven(topping) // each pizza takes 10 minutes!
+  },
+)
+
+// Later on, if you need to abort:
+abortController.abort()
+```
+
+### Aggregate Errors
+
+Once the whole array has been processed, `parallel` will check for errors. If any errors occurred during processing, they are combined into a single `AggregateError`. The `AggregateError` has an `errors` array property which contains all the individual errors that were thrown.
 
 ```ts
 import * as _ from 'radashi'
@@ -43,32 +60,5 @@ const [err, users] = await _.tryit(_.parallel)(3, userIds, async userId => {
 
 console.log(err) // => AggregateError
 console.log(err.errors) // => [Error, Error, Error]
-console.log(err.errors[1].message) // => No, I don't want to find user 2
-```
-
-When aborting, it will throw a single `Error` with the message `Operation aborted`.
-
-```ts
-import * as _ from 'radashi'
-
-const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-const abortController = new AbortController()
-const signal = abortController.signal
-
-const [err, users] = await _.tryit(_.parallel)(
-  {
-    limit: 3,
-    signal: signal,
-  },
-  userIds,
-  async userId => {
-    return await api.users.find(userId)
-  },
-)
-
-// To abort the operation:
-abortController.abort()
-
-console.log(err) // => Error: Operation Aborted
-console.log(err.message) // => "Operation Aborted"
+console.log(err.errors[1].message) // => "No, I don't want to find user 2"
 ```

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Like `_.map` but built specifically to run the async callback functions
 in parallel. The first argument is a limit of how many functions should
-be allowed to run at once. 
+be allowed to run at once.
 
 Optionally, you can pass `AbortController.signal` as the last parameter to abort the operation if needed.
 
@@ -55,9 +55,16 @@ const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 const abortController = new AbortController()
 const signal = abortController.signal
 
-const [err, users] = await _.tryit(_.parallel)(3, userIds, async userId => {
-  return await api.users.find(userId)
-}, signal)
+const [err, users] = await _.tryit(_.parallel)(
+  {
+    limit: 3,
+    signal: signal,
+  },
+  userIds,
+  async userId => {
+    return await api.users.find(userId)
+  },
+)
 
 // To abort the operation:
 abortController.abort()

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -8,7 +8,11 @@ since: 12.1.0
 
 Like `_.map` but built specifically to run the async callback functions
 in parallel. The first argument is a limit of how many functions should
-be allowed to run at once. Returns an array of results.
+be allowed to run at once. 
+
+Optionally, you can pass `AbortController.signal` as the last parameter to abort the operation if needed.
+
+Returns an array of results.
 
 ```ts
 import * as _ from 'radashi'
@@ -40,4 +44,24 @@ const [err, users] = await _.tryit(_.parallel)(3, userIds, async userId => {
 console.log(err) // => AggregateError
 console.log(err.errors) // => [Error, Error, Error]
 console.log(err.errors[1].message) // => No, I don't want to find user 2
+```
+
+When aborting, it will throw a single `Error` with the message `Operation aborted`.
+
+```ts
+import * as _ from 'radashi'
+
+const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+const abortController = new AbortController()
+const signal = abortController.signal
+
+const [err, users] = await _.tryit(_.parallel)(3, userIds, async userId => {
+  return await api.users.find(userId)
+}, signal)
+
+// To abort the operation:
+abortController.abort()
+
+console.log(err) // => Error: Operation Aborted
+console.log(err.message) // => "Operation Aborted"
 ```

--- a/docs/async/retry.mdx
+++ b/docs/async/retry.mdx
@@ -1,18 +1,20 @@
 ---
 title: retry
-description: Run an async function retrying if it fails
+description: Retry an async function when it fails
 since: 12.1.0
 ---
 
 ### Usage
 
-The `_.retry` function allows you to run an async function and automagically retry it if it fails. Given the async func to run, an optional max number of retries (`r`), and an optional milliseconds to delay between retries (`d`), the given async function will be called, retrying `r` many times, and waiting `d` milliseconds between retries.
+The `retry` function runs an async function and retries it if it fails. You can specify how many times to retry, how long to wait between retries, and whether to use exponential backoff.
 
-The `times` option defaults to `3`. The `delay` option (defaults to null) can specify milliseconds to sleep between attempts.
+**Options**
 
-The `backoff` option is like delay but uses a function to sleep -- makes for easy exponential backoff.
-
-The `signal` option allows you to pass an AbortSignal to abort the retry operation if needed.
+- `times` is the maximum number of times to retry (default: `3`)
+- `delay` is milliseconds to sleep between retries
+- `backoff` is a function called to calculate the delay between retries
+  - It receives the attempt number (starting with `1`) and returns the delay in milliseconds.
+- `signal` allows you to pass an `AbortController.signal` to interrupt the retry operation
 
 ```ts
 import * as _ from 'radashi'
@@ -34,20 +36,27 @@ await _.retry({ times: 2, delay: 1000 }, api.users.list) // try 2 times with 1 s
 
 // exponential backoff
 await _.retry({ backoff: i => 10 ** i }, api.users.list) // try 3 times with 10, 100, 1000 ms delay
+```
 
-// aborting the retry operation
+### Interrupting
+
+If a `signal` is passed, the retry operation can be interrupted. When the signal is aborted, `retry`'s promise will reject with a `DOMException` (even in Node.js) with the message `This operation was aborted` and name `AbortError`.
+
+```ts
+import * as _ from 'radashi'
+
 const abortController = new AbortController()
 const signal = abortController.signal
 
 const promise = _.retry({ times: 3, delay: 1000, signal }, api.users.list)
 
-// To abort the operation:
+// To stop retrying immediately:
 abortController.abort()
 
 try {
   await promise
 } catch (err) {
-  if (err.message === 'Operation aborted') {
+  if (err.message === 'This operation was aborted') {
     console.log('Retry operation was aborted')
   }
 }

--- a/docs/async/retry.mdx
+++ b/docs/async/retry.mdx
@@ -12,7 +12,7 @@ The `times` option defaults to `3`. The `delay` option (defaults to null) can sp
 
 The `backoff` option is like delay but uses a function to sleep -- makes for easy exponential backoff.
 
-The signal option allows you to pass an AbortSignal to abort the retry operation if needed.
+The `signal` option allows you to pass an AbortSignal to abort the retry operation if needed.
 
 ```ts
 import * as _ from 'radashi'

--- a/docs/async/retry.mdx
+++ b/docs/async/retry.mdx
@@ -12,6 +12,8 @@ The `times` option defaults to `3`. The `delay` option (defaults to null) can sp
 
 The `backoff` option is like delay but uses a function to sleep -- makes for easy exponential backoff.
 
+The signal option allows you to pass an AbortSignal to abort the retry operation if needed.
+
 ```ts
 import * as _ from 'radashi'
 
@@ -32,4 +34,21 @@ await _.retry({ times: 2, delay: 1000 }, api.users.list) // try 2 times with 1 s
 
 // exponential backoff
 await _.retry({ backoff: i => 10 ** i }, api.users.list) // try 3 times with 10, 100, 1000 ms delay
+
+// aborting the retry operation
+const abortController = new AbortController()
+const signal = abortController.signal
+
+const promise = _.retry({ times: 3, delay: 1000, signal }, api.users.list)
+
+// To abort the operation:
+abortController.abort()
+
+try {
+  await promise
+} catch (err) {
+  if (err.message === 'Operation aborted') {
+    console.log('Retry operation was aborted')
+  }
+}
 ```

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -78,7 +78,6 @@ export async function parallel<T, K>(
   ) => {
     const results: WorkItemResult<K>[] = []
     const abortListener = () => reject(new Error('This operation was aborted'))
-
     options.signal?.addEventListener('abort', abortListener)
     while (true) {
       const next = work.pop()
@@ -92,9 +91,7 @@ export async function parallel<T, K>(
         index: next.index,
       })
     }
-
     options.signal?.removeEventListener('abort', abortListener)
-
     return resolve(results)
   }
   const queues = list(1, options.limit).map(() => new Promise(processor))

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -10,13 +10,7 @@ import {
 
 type AbortSignal = {
   readonly aborted: boolean
-  addEventListener(
-    type: 'abort',
-    listener: () => void,
-    options?: {
-      once: boolean
-    },
-  ): void
+  addEventListener(type: 'abort', listener: () => void): void
   removeEventListener(type: 'abort', listener: () => void): void
   throwIfAborted(): void
 }

--- a/src/async/retry.ts
+++ b/src/async/retry.ts
@@ -36,9 +36,6 @@ export async function retry<TResponse>(
     const [err, result] = (await tryit(func)((err: any) => {
       throw { _exited: err }
     })) as [any, TResponse]
-
-    console.log(signal)
-
     if (signal?.aborted) {
       throw new Error('Operation aborted')
     }

--- a/src/async/retry.ts
+++ b/src/async/retry.ts
@@ -1,5 +1,9 @@
 import { sleep, tryit } from 'radashi'
 
+type AbortSignal = {  
+  throwIfAborted(): void  
+}  
+
 export type RetryOptions = {
   times?: number
   delay?: number | null
@@ -36,9 +40,7 @@ export async function retry<TResponse>(
     const [err, result] = (await tryit(func)((err: any) => {
       throw { _exited: err }
     })) as [any, TResponse]
-    if (signal?.aborted) {
-      throw new Error('Operation aborted')
-    }
+    signal?.throwIfAborted()
     if (!err) {
       return result
     }

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -37,4 +37,25 @@ describe('parallel', () => {
     })
     expect(Math.max(...tracking)).toBe(3)
   })
+  test('aborts the operation when the signal is triggered', async () => {
+    const abortController = new AbortController()
+
+    setTimeout(() => abortController.abort(), 150)
+
+    const [error, results] = await _.try(async () => {
+      return _.parallel(
+        1,
+        _.list(1, 3),
+        async num => {
+          await _.sleep(50)
+          return `hi_${num}`
+        },
+        abortController.signal,
+      )
+    })()
+
+    expect(results).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe('Operation aborted')
+  })
 })

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -83,4 +83,29 @@ describe('parallel', () => {
     expect(error).toBeInstanceOf(Error)
     expect(error?.message).toBe('This operation was aborted')
   })
+  test('removes abort event listener after completion', async () => {
+    const mockAbortSignal = {
+      aborted: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      throwIfAborted: vi.fn(),
+    }
+
+    await _.parallel(
+      {
+        limit: 2,
+        signal: mockAbortSignal,
+      },
+      _.list(1, 5),
+      async num => {
+        await new Promise(resolve => setTimeout(resolve, 10))
+        return `hi_${num}`
+      },
+    )
+
+    expect(mockAbortSignal.removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    )
+  })
 })

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -11,6 +11,7 @@ describe('parallel', () => {
     expect(errors).toBeUndefined()
     expect(results).toEqual(['hi_1', 'hi_2', 'hi_3'])
   })
+
   test('throws errors as array of all errors', async () => {
     const [error, results] = await _.try(async () => {
       return _.parallel(1, _.list(1, 3), async num => {
@@ -26,6 +27,7 @@ describe('parallel', () => {
     expect(err.errors.length).toBe(1)
     expect(err.errors[0].message).toBe('number is 2')
   })
+
   test('does not run more than the limit at once', async () => {
     let numInProgress = 0
     const tracking: number[] = []
@@ -37,73 +39,72 @@ describe('parallel', () => {
     })
     expect(Math.max(...tracking)).toBe(3)
   })
-  test('aborts the operation when the signal is triggered', async () => {
-    const abortController = new AbortController()
 
-    setTimeout(() => abortController.abort(), 150)
+  test('abort before all iterations are complete', async () => {
+    vi.useFakeTimers()
 
-    const [error, results] = await _.try(async () => {
-      return _.parallel(
+    const ctrl = new AbortController()
+
+    // Abort in the middle of the 3rd iteration.
+    setTimeout(() => ctrl.abort(), 25)
+
+    const callback = vi.fn(() => _.sleep(10))
+    const promise = _.parallel(
+      {
+        limit: 1,
+        signal: ctrl.signal,
+      },
+      _.list(1, 10),
+      callback,
+    )
+    promise.catch(_.noop)
+
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(promise).rejects.toThrowError(
+      new DOMException('This operation was aborted', 'AbortError'),
+    )
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  test('abort before first iteration begins', async () => {
+    const ctrl = new AbortController()
+    ctrl.abort()
+
+    const callback = vi.fn()
+    await expect(
+      _.parallel(
         {
           limit: 1,
-          signal: abortController.signal,
+          signal: ctrl.signal,
         },
-        _.list(1, 12),
-        async num => {
-          await _.sleep(50)
-          return `hi_${num}`
-        },
-      )
-    })()
-
-    expect(results).toBeUndefined()
-    expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toBe('This operation was aborted')
+        _.list(1, 5),
+        callback,
+      ),
+    ).rejects.toThrowError(
+      new DOMException('This operation was aborted', 'AbortError'),
+    )
+    expect(callback).not.toHaveBeenCalled()
   })
-  test('should throw if the abort controller aborted before first iteration has finished execution', async () => {
-    const abortController = new AbortController()
 
-    abortController.abort()
+  test('remove abort listener after completion', async () => {
+    vi.useFakeTimers()
 
-    const [error, results] = await _.try(async () => {
-      return _.parallel(
-        {
-          limit: 1,
-          signal: abortController.signal,
-        },
-        _.list(1, 24),
-        async num => {
-          await _.sleep(50)
-          return `hi_${num}`
-        },
-      )
-    })()
+    const ctrl = new AbortController()
+    const removeEventListener = vi.spyOn(ctrl.signal, 'removeEventListener')
 
-    expect(results).toBeUndefined()
-    expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toBe('This operation was aborted')
-  })
-  test('removes abort event listener after completion', async () => {
-    const mockAbortSignal = {
-      aborted: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      throwIfAborted: vi.fn(),
-    }
-
+    const callback = vi.fn()
     await _.parallel(
       {
         limit: 2,
-        signal: mockAbortSignal,
+        signal: ctrl.signal,
       },
       _.list(1, 5),
-      async num => {
-        await new Promise(resolve => setTimeout(resolve, 10))
-        return `hi_${num}`
-      },
+      callback,
     )
 
-    expect(mockAbortSignal.removeEventListener).toHaveBeenCalledWith(
+    expect(callback).toHaveBeenCalledTimes(5)
+    expect(removeEventListener).toHaveBeenCalledWith(
       'abort',
       expect.any(Function),
     )

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -44,18 +44,43 @@ describe('parallel', () => {
 
     const [error, results] = await _.try(async () => {
       return _.parallel(
-        1,
-        _.list(1, 3),
+        {
+          limit: 1,
+          signal: abortController.signal,
+        },
+        _.list(1, 12),
         async num => {
           await _.sleep(50)
           return `hi_${num}`
         },
-        abortController.signal,
       )
     })()
 
     expect(results).toBeUndefined()
     expect(error).toBeInstanceOf(Error)
-    expect(error?.message).toBe('Operation aborted')
+    expect(error?.message).toBe('This operation was aborted')
+  })
+  test('should throw if the abort controller aborted before first iteration has finished execution', async () => {
+    const abortController = new AbortController()
+
+    abortController.abort()
+
+    const [error, results] = await _.try(async () => {
+      return _.parallel(
+        {
+          limit: 1,
+          signal: abortController.signal,
+        },
+        _.list(1, 24),
+        async num => {
+          await _.sleep(50)
+          return `hi_${num}`
+        },
+      )
+    })()
+
+    expect(results).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe('This operation was aborted')
   })
 })

--- a/tests/async/retry.test.ts
+++ b/tests/async/retry.test.ts
@@ -129,7 +129,7 @@ describe('retry', () => {
       })
     } catch (err) {
       expect(err).toBeInstanceOf(Error)
-      expect((err as Error).message).toBe('Operation aborted')
+      expect((err as Error).message).toBe('This operation was aborted')
       return
     }
 

--- a/tests/async/retry.test.ts
+++ b/tests/async/retry.test.ts
@@ -1,7 +1,7 @@
 // cSpell:ignore backoffs
 
-import * as _ from 'radashi'
 import type { RetryOptions } from 'radashi'
+import * as _ from 'radashi'
 
 const cast = <T = RetryOptions>(value: any): T => value
 
@@ -115,5 +115,24 @@ describe('retry', () => {
     // The performance typically comes in 1
     // or 2 milliseconds after.
     expect(diff).toBeGreaterThanOrEqual(backoffs)
+  })
+  test('aborts the retry operation when signal is aborted', async () => {
+    try {
+      const abortController = new AbortController()
+      let attempt = 0
+      await _.retry({ signal: abortController.signal }, async () => {
+        attempt++
+        if (attempt === 2) {
+          abortController.abort()
+        }
+        throw 'quit again'
+      })
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error)
+      expect((err as Error).message).toBe('Operation aborted')
+      return
+    }
+
+    expect.fail('error should have been thrown')
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDeclarationOnly": true,
     "isolatedDeclarations": true,
     "target": "es2017",
-    "lib": ["es2017"],
+    "lib": ["es2017", "DOM"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDeclarationOnly": true,
     "isolatedDeclarations": true,
     "target": "es2017",
-    "lib": ["es2017", "DOM"],
+    "lib": ["es2017"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

This PR adds an option to pass `AbortController.signal` to `retry` and `parallel` to end their execution before looping over all of the array items, or going through all of the retry attempts. When aborted, the functions throw an `Error` with the message `Operation aborted`.

```ts
// _.retry
import * as _ from 'radashi'

const abortController = new AbortController()
const signal = abortController.signal

const promise = _.retry({ times: 3, delay: 1000, signal }, api.users.list)

// To abort the operation:
abortController.abort()

try {
  await promise
} catch (err) {
  if (err.message === 'Operation aborted') {
    console.log('Retry operation was aborted')
  }
}

//_.parallel
import * as _ from 'radashi'

const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9]
const abortController = new AbortController()
const signal = abortController.signal

const [err, users] = await _.tryit(_.parallel)(3, userIds, async userId => {
  return await api.users.find(userId)
}, signal)

// To abort the operation:
abortController.abort()

console.log(err) // => Error: Operation Aborted
console.log(err.message) // => "Operation Aborted"
```

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

https://github.com/radashi-org/radashi/issues/255
https://github.com/orgs/radashi-org/discussions/256

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->

I do not know entirely what are the implications of this change, but I added the `DOM` parameter to `lib` in `tsconfig.json`. According to [this article](https://www.totaltypescript.com/tsconfig-cheat-sheet#running-in-the-dom), it adds the types for browser API's which in this case includes the `AbortController`. According to [`can i use`](https://caniuse.com/?search=AbortController), it is supported in all major browsers and has been implemented in node since v15, so it shouldn't break any existing applications using older versions of radashi.

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/parallel.ts` | 1563 | +291 (+23%) |
| M | `src/async/retry.ts` | 535 | +32 (+6%) |

[^1337]: Function size includes the `import` dependencies of the function.



