### PR TITLE
test(isEqual): add order-agnostic cases for Set and Map

### DIFF
--- a/tests/typed/isEqual.test.ts
+++ b/tests/typed/isEqual.test.ts
@@ -46,6 +46,16 @@ describe('isEqual', () => {
     expect(
       _.isEqual([complex, complex], [{ ...complex }, { ...complex }]),
     ).toBeTruthy()
+    expect(_.isEqual(new Map([
+      [1, "one"],
+      [2, "two"],
+      [3, "three"],
+    ]), new Map([
+      [3, "three"],
+      [2, "two"],
+      [1, "one"],
+    ]))).toBeTruthy();
+    expect(_.isEqual(new Set([1,2,3]), new Set([3,2,1]))).toBeTruthy()
   })
   test('returns false for non-equal things', () => {
     expect(_.isEqual(0, 1)).toBeFalsy()


### PR DESCRIPTION
<!--/publish-->

## Summary

This PR adds 2 already succeeding test cases for Javascript Sets and Maps to further ensure that `isEqual` works as expected. The test cases assure that Maps and Sets are compared agnostic of insertion order.

## Related issue, if any:

[Adding testcases for Sets and Maps agnostic of insertion order](https://github.com/radashi-org/radashi/issues/268)

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

No


I'm currently NOT running on a linux machine and cannot run the linting due to the bash dependecy. I will try to install wsl soon but wont be able to do it now.
