### PR TITLE
feat(types): allow readonly array in `omit` function

### DIFF
--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -13,7 +13,7 @@
  */
 export function omit<T, TKeys extends keyof T>(
   obj: T,
-  keys: TKeys[],
+  keys: readonly TKeys[],
 ): Omit<T, TKeys> {
   if (!obj) {
     return {} as Omit<T, TKeys>
@@ -21,6 +21,7 @@ export function omit<T, TKeys extends keyof T>(
   if (!keys || keys.length === 0) {
     return obj as Omit<T, TKeys>
   }
+
   return keys.reduce(
     (acc, key) => {
       // Gross, I know, it's mutating the object, but we are allowing

--- a/src/object/omit.ts
+++ b/src/object/omit.ts
@@ -21,7 +21,6 @@ export function omit<T, TKeys extends keyof T>(
   if (!keys || keys.length === 0) {
     return obj as Omit<T, TKeys>
   }
-
   return keys.reduce(
     (acc, key) => {
       // Gross, I know, it's mutating the object, but we are allowing

--- a/tests/object/omit.test.ts
+++ b/tests/object/omit.test.ts
@@ -21,7 +21,7 @@ describe('omit', () => {
     expect(result).toEqual(person)
   })
   test('returns object without omitted properties', () => {
-    const result = _.omit(person, ['name'] )
+    const result = _.omit(person, ['name'])
     expect(result).toEqual({
       age: 20,
       active: true,

--- a/tests/object/omit.test.ts
+++ b/tests/object/omit.test.ts
@@ -31,7 +31,6 @@ describe('omit', () => {
     const keysToOmit = ['name', 'age'] as const;
     const result = _.omit(person, keysToOmit)
     expect(result).toEqual({
-      age: 20,
       active: true,
     })
   })

--- a/tests/object/omit.test.ts
+++ b/tests/object/omit.test.ts
@@ -27,11 +27,4 @@ describe('omit', () => {
       active: true,
     })
   })
-  test('returns object without omitted properties when keys are readonly', () => {
-    const keysToOmit = ['name', 'age'] as const;
-    const result = _.omit(person, keysToOmit)
-    expect(result).toEqual({
-      active: true,
-    })
-  })
 })

--- a/tests/object/omit.test.ts
+++ b/tests/object/omit.test.ts
@@ -21,7 +21,15 @@ describe('omit', () => {
     expect(result).toEqual(person)
   })
   test('returns object without omitted properties', () => {
-    const result = _.omit(person, ['name'])
+    const result = _.omit(person, ['name'] )
+    expect(result).toEqual({
+      age: 20,
+      active: true,
+    })
+  })
+  test('returns object without omitted properties when keys are readonly', () => {
+    const keysToOmit = ['name', 'age'] as const;
+    const result = _.omit(person, keysToOmit)
     expect(result).toEqual({
       age: 20,
       active: true,


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary
This pull request is an enhancement to the omit function, allowing it to accept `readonly` array keys. This means that the keys array cannot be modified within the function

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:
https://github.com/radashi-org/radashi/issues/267

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->
No

<!-- If yes, describe the impact and migration path for existing applications. -->
