### PR TITLE
fix(types): improve signature of `shake`

### DIFF
--- a/src/object/shake.ts
+++ b/src/object/shake.ts
@@ -2,6 +2,8 @@
  * Removes (shakes out) undefined entries from an object. Optional
  * second argument shakes out values by custom evaluation.
  *
+ * Note that non-enumerable keys are never shaken out.
+ *
  * @see https://radashi.js.org/reference/object/shake
  * @example
  * ```ts
@@ -13,13 +15,23 @@
  */
 export function shake<T extends object>(
   obj: T,
-  filter: (value: T[keyof T]) => boolean = value => value === undefined,
+): {
+  [K in keyof T]: Exclude<T[K], undefined>
+}
+
+export function shake<T extends object>(
+  obj: T,
+  filter: ((value: unknown) => boolean) | undefined,
+): T
+
+export function shake<T extends object>(
+  obj: T,
+  filter: (value: unknown) => boolean = value => value === undefined,
 ): T {
   if (!obj) {
     return {} as T
   }
-  const keys = Object.keys(obj) as (keyof T)[]
-  return keys.reduce((acc, key) => {
+  return (Object.keys(obj) as (keyof T)[]).reduce((acc, key) => {
     if (!filter(obj[key])) {
       acc[key] = obj[key]
     }

--- a/tests/object/shake.test-d.ts
+++ b/tests/object/shake.test-d.ts
@@ -1,0 +1,46 @@
+import { shake } from 'radashi'
+
+describe('shake', () => {
+  test('object with possibly undefined values', () => {
+    // Undefined values are removed.
+    const result = shake({} as { a: string | undefined })
+    expectTypeOf(result).toEqualTypeOf<{ a: string }>()
+  })
+
+  test('object with optional properties', () => {
+    // Optional properties must not be affected, because we don't know
+    // whether they exist on the object at runtime.
+    const result = shake({} as { a?: string })
+    expectTypeOf(result).toEqualTypeOf<{ a?: string }>()
+
+    // When using exactOptionalPropertyTypes, optional properties
+    // *will* have their undefined values removed, but their
+    // optionality still won't be affected.
+    const result2 = shake({} as { a?: string | undefined }, undefined)
+    expectTypeOf(result2).toEqualTypeOf<{ a?: string }>()
+  })
+
+  test('Record type', () => {
+    // Undefined values are removed.
+    const result = shake({} as Record<string, string | undefined>)
+    expectTypeOf(result).toEqualTypeOf<Record<string, string>>()
+
+    // Allows any property key. Preserves null values.
+    const result2 = shake({} as Record<keyof any, string | null | undefined>)
+    expectTypeOf(result2).toEqualTypeOf<Record<keyof any, string | null>>()
+  })
+
+  test('with filter function', () => {
+    // We cannot assume *anything* about the return type when a filter
+    // function is used. You can use type assertions to “fix” the
+    // return type in this case.
+    const result = shake({} as { a: string | undefined }, value => {
+      // We cannot assume *anything* about the value parameter,
+      // since “object assignability” is not strict in TypeScript.
+      expectTypeOf(value).toEqualTypeOf<unknown>()
+
+      return value === undefined
+    })
+    expectTypeOf(result).toEqualTypeOf<{ a: string | undefined }>()
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

When no `filter` argument is passed to `shake`, we can narrow property types to exclude undefined. Notably, optionality of properties (i.e. `foo?: string`) must not be affected, since `shake` does not guarantee the existence of any property; it only guarantees that a *defined* property does not have an `undefined` value (oh JavaScript, you absolute mad lad).

## Related issue, if any:

[This issue](https://github.com/sodiray/radash/issues/388) inspired me to take a closer look at our version of `shake`, so you could say it's fixed by this PR.

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


