### PR TITLE
fix(types): let `zipToObject` receive readonly arrays

### DIFF
--- a/src/array/zipToObject.ts
+++ b/src/array/zipToObject.ts
@@ -19,8 +19,8 @@ import { isArray, isFunction } from 'radashi'
  * @version 12.1.0
  */
 export function zipToObject<K extends string | number | symbol, V>(
-  keys: K[],
-  values: V | ((key: K, idx: number) => V) | V[],
+  keys: readonly K[],
+  values: V | ((key: K, idx: number) => V) | readonly V[],
 ): Record<K, V> {
   if (!keys || !keys.length) {
     return {} as Record<K, V>

--- a/tests/array/zipToObject.test-d.ts
+++ b/tests/array/zipToObject.test-d.ts
@@ -1,12 +1,31 @@
 import * as _ from 'radashi'
 
 describe('zipToObject', () => {
-  test('readonly arrays', () => {
+  test('mutable arrays with loose types', () => {
+    const names = ['ra', 'zeus', 'loki']
+    const followers = [1000000, 500000, 250000]
+    expectTypeOf(_.zipToObject(names, followers)).toEqualTypeOf<
+      Record<string, number>
+    >()
+  })
+
+  test('readonly arrays with string literals', () => {
     const names = ['ra', 'zeus', 'loki'] as const
     const cultures = ['egypt', 'greek', 'norse'] as const
 
     expectTypeOf(_.zipToObject(names, cultures)).toEqualTypeOf<
       Record<'ra' | 'zeus' | 'loki', 'egypt' | 'greek' | 'norse'>
     >()
+  })
+
+  test('inline array and single value', () => {
+    // Note how the value type is widened to `number`.
+    const result = _.zipToObject(['a', 'b'], 1)
+    expectTypeOf(result).toEqualTypeOf<Record<'a' | 'b', number>>()
+  })
+
+  test('empty array', () => {
+    const result = _.zipToObject([], 1)
+    expectTypeOf(result).toEqualTypeOf<Record<never, number>>()
   })
 })

--- a/tests/array/zipToObject.test-d.ts
+++ b/tests/array/zipToObject.test-d.ts
@@ -1,10 +1,12 @@
 import * as _ from 'radashi'
 
-test('readonly arrays', () => {
-  const names = ['ra', 'zeus', 'loki'] as const
-  const cultures = ['egypt', 'greek', 'norse'] as const
+describe('zipToObject', () => {
+  test('readonly arrays', () => {
+    const names = ['ra', 'zeus', 'loki'] as const
+    const cultures = ['egypt', 'greek', 'norse'] as const
 
-  expectTypeOf(_.zipToObject(names, cultures)).toEqualTypeOf<
-    Record<'ra' | 'zeus' | 'loki', 'egypt' | 'greek' | 'norse'>
-  >()
+    expectTypeOf(_.zipToObject(names, cultures)).toEqualTypeOf<
+      Record<'ra' | 'zeus' | 'loki', 'egypt' | 'greek' | 'norse'>
+    >()
+  })
 })

--- a/tests/array/zipToObject.test-d.ts
+++ b/tests/array/zipToObject.test-d.ts
@@ -1,0 +1,10 @@
+import * as _ from 'radashi'
+
+test('readonly arrays', () => {
+  const names = ['ra', 'zeus', 'loki'] as const
+  const cultures = ['egypt', 'greek', 'norse'] as const
+
+  expectTypeOf(_.zipToObject(names, cultures)).toEqualTypeOf<
+    Record<'ra' | 'zeus' | 'loki', 'egypt' | 'greek' | 'norse'>
+  >()
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

The zipToObject function did not work with readonly/const arrays

## Related issue, if any:

#288

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [X] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->








