### PR TITLE
fix(types): `mapValues` index signature handling

### DIFF
--- a/src/object/mapValues.ts
+++ b/src/object/mapValues.ts
@@ -10,42 +10,15 @@
  * ```
  * @version 12.1.0
  */
-export function mapValues<
-  TValue,
-  TKey extends string | number | symbol,
-  TNewValue,
->(
-  obj: { [K in TKey]: TValue },
-  mapFunc: (value: TValue, key: TKey) => TNewValue,
-): { [K in TKey]: TNewValue }
-
-// This overload exists to support cases where `obj` is a partial
-// object whose values are never undefined when the key is also
-// defined. For example:
-//   { [key: string]?: number } versus { [key: string]: number | undefined }
-export function mapValues<
-  TValue,
-  TKey extends string | number | symbol,
-  TNewValue,
->(
-  obj: { [K in TKey]?: TValue },
-  mapFunc: (value: TValue, key: TKey) => TNewValue,
-): { [K in TKey]?: TNewValue }
-
-export function mapValues<
-  TValue,
-  TKey extends string | number | symbol,
-  TNewValue,
->(
-  obj: { [K in TKey]?: TValue },
-  mapFunc: (value: TValue, key: TKey) => TNewValue,
-): Record<TKey, TNewValue> {
-  const keys = Object.keys(obj) as TKey[]
-  return keys.reduce(
+export function mapValues<T extends object, U>(
+  obj: T,
+  mapFunc: (value: T[keyof T], key: keyof T) => U,
+): { [K in keyof T]: U } {
+  return (Object.keys(obj) as (keyof T)[]).reduce(
     (acc, key) => {
-      acc[key] = mapFunc(obj[key]!, key)
+      acc[key] = mapFunc(obj[key], key)
       return acc
     },
-    {} as Record<TKey, TNewValue>,
+    {} as { [K in keyof T]: U },
   )
 }

--- a/src/object/mapValues.ts
+++ b/src/object/mapValues.ts
@@ -12,7 +12,7 @@
  */
 export function mapValues<T extends object, U>(
   obj: T,
-  mapFunc: (value: T[keyof T], key: keyof T) => U,
+  mapFunc: (value: Required<T>[keyof T], key: keyof T) => U,
 ): { [K in keyof T]: U } {
   return (Object.keys(obj) as (keyof T)[]).reduce(
     (acc, key) => {

--- a/tests/object/mapValues.test-d.ts
+++ b/tests/object/mapValues.test-d.ts
@@ -2,22 +2,28 @@ import { mapValues } from 'radashi'
 
 describe('mapValues', () => {
   test('Record types', () => {
-    const object = mapValues({} as Record<string, number>, x => String(x))
+    const object = mapValues({} as Record<string, number>, x => x.toFixed(2))
     expectTypeOf(object).toEqualTypeOf<Record<string, string>>()
   })
 
   test('index signature types', () => {
-    const object = mapValues({} as { [key: string]: number }, x => String(x))
+    const object = mapValues({} as { [key: string]: number }, x => x.toFixed(2))
     expectTypeOf(object).toEqualTypeOf<{ [key: string]: string }>()
   })
 
   test('literal types', () => {
-    const object = mapValues({} as { a: number }, x => String(x))
+    const object = mapValues({} as { a: number }, x => x.toFixed(2))
     expectTypeOf(object).toEqualTypeOf<{ a: string }>()
   })
 
   test('optional types', () => {
-    const object = mapValues({} as { a?: number }, x => String(x))
+    const object = mapValues({} as { a?: number }, x => {
+      // Due to exactOptionalPropertyTypes, the type-checker knows
+      // that `x` will never be undefined, because `mapValues` can
+      // only process keys that are present.
+      expectTypeOf(x).toEqualTypeOf<number>()
+      return x.toFixed(2)
+    })
     expectTypeOf(object).toEqualTypeOf<{ a?: string }>()
   })
 })

--- a/tests/object/mapValues.test-d.ts
+++ b/tests/object/mapValues.test-d.ts
@@ -1,0 +1,23 @@
+import { mapValues } from 'radashi'
+
+describe('mapValues', () => {
+  test('Record types', () => {
+    const object = mapValues({} as Record<string, number>, x => String(x))
+    expectTypeOf(object).toEqualTypeOf<Record<string, string>>()
+  })
+
+  test('index signature types', () => {
+    const object = mapValues({} as { [key: string]: number }, x => String(x))
+    expectTypeOf(object).toEqualTypeOf<{ [key: string]: string }>()
+  })
+
+  test('literal types', () => {
+    const object = mapValues({} as { a: number }, x => String(x))
+    expectTypeOf(object).toEqualTypeOf<{ a: string }>()
+  })
+
+  test('optional types', () => {
+    const object = mapValues({} as { a?: number }, x => String(x))
+    expectTypeOf(object).toEqualTypeOf<{ a?: string }>()
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

`mapValues` was incorrectly handling index signatures at the type level:

```ts
// BEFORE
const object = mapValues({} as { [key: string]: number }, x => String(x))
//    ^? { [key: string]: string; [key: number]: string }

// AFTER
const object = mapValues({} as { [key: string]: number }, x => String(x))
//    ^? { [key: string]: string }
```

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->




