### PR TITLE
fix(all): be more lenient, reduce memory usage

### DIFF
--- a/src/async/all.ts
+++ b/src/async/all.ts
@@ -15,7 +15,11 @@ import { AggregateError, isArray } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export async function all<const T extends readonly unknown[]>(
+export async function all<T extends readonly [unknown, ...unknown[]]>(
+  input: T,
+): Promise<{ -readonly [I in keyof T]: Awaited<T[I]> }>
+
+export async function all<T extends readonly unknown[]>(
   input: T,
 ): Promise<{ -readonly [I in keyof T]: Awaited<T[I]> }>
 

--- a/src/async/all.ts
+++ b/src/async/all.ts
@@ -1,13 +1,8 @@
 import { AggregateError, isArray } from 'radashi'
 
-type PromiseValues<T extends Promise<any>[]> = {
-  [K in keyof T]: T[K] extends Promise<infer U> ? U : never
-}
-
 /**
- * Functionally similar to `Promise.all` or `Promise.allSettled`. If
- * any errors are thrown, all errors are gathered and thrown in an
- * `AggregateError`.
+ * Wait for all promises to resolve. Errors from rejected promises are
+ * collected into an `AggregateError`.
  *
  * @see https://radashi.js.org/reference/async/all
  * @example
@@ -20,18 +15,18 @@ type PromiseValues<T extends Promise<any>[]> = {
  * ```
  * @version 12.1.0
  */
-export async function all<T extends [Promise<any>, ...Promise<any>[]]>(
-  promises: T,
-): Promise<PromiseValues<T>>
-
-export async function all<T extends Promise<any>[]>(
-  promises: T,
-): Promise<PromiseValues<T>>
+export async function all<const T extends readonly unknown[]>(
+  input: T,
+): Promise<{ -readonly [I in keyof T]: Awaited<T[I]> }>
 
 /**
- * Functionally similar to `Promise.all` or `Promise.allSettled`. If
- * any errors are thrown, all errors are gathered and thrown in an
- * `AggregateError`.
+ * Check each property in the given object for a promise value. Wait
+ * for all promises to resolve. Errors from rejected promises are
+ * collected into an `AggregateError`.
+ *
+ * The returned promise will resolve with an object whose keys are
+ * identical to the keys of the input object. The values are the
+ * resolved values of the promises.
  *
  * @see https://radashi.js.org/reference/async/all
  * @example
@@ -43,39 +38,35 @@ export async function all<T extends Promise<any>[]>(
  * })
  * ```
  */
-export async function all<T extends Record<string, Promise<any>>>(
-  promises: T,
-): Promise<{ [K in keyof T]: Awaited<T[K]> }>
+export async function all<T extends Record<string, unknown>>(
+  input: T,
+): Promise<{ -readonly [K in keyof T]: Awaited<T[K]> }>
 
 export async function all(
-  promises: Record<string, Promise<any>> | Promise<any>[],
+  input: Record<string, unknown> | readonly unknown[],
 ): Promise<any> {
-  const entries = isArray(promises)
-    ? promises.map(p => [null, p] as const)
-    : Object.entries(promises)
-
-  const results = await Promise.all(
-    entries.map(([key, value]) =>
-      value
-        .then(result => ({ result, exc: null, key }))
-        .catch(exc => ({ result: null, exc, key })),
-    ),
-  )
-
-  const exceptions = results.filter(r => r.exc)
-  if (exceptions.length > 0) {
-    throw new AggregateError(exceptions.map(e => e.exc))
+  const errors: any[] = []
+  const onError = (err: any) => {
+    errors.push(err)
   }
 
-  if (isArray(promises)) {
-    return results.map(r => r.result)
+  let output: any
+  if (isArray(input)) {
+    output = await Promise.all(
+      input.map(value => Promise.resolve(value).catch(onError)),
+    )
+  } else {
+    output = { ...input }
+    await Promise.all(
+      Object.keys(output).map(async key => {
+        output[key] = await Promise.resolve(output[key]).catch(onError)
+      }),
+    )
   }
 
-  return results.reduce(
-    (acc, item) => {
-      acc[item.key!] = item.result
-      return acc
-    },
-    {} as Record<string, any>,
-  )
+  if (errors.length > 0) {
+    throw new AggregateError(errors)
+  }
+
+  return output
 }

--- a/tests/async/all.test-d.ts
+++ b/tests/async/all.test-d.ts
@@ -21,6 +21,12 @@ describe('all', () => {
     expectTypeOf(result).toEqualTypeOf<[1, 2, 3]>()
   })
 
+  test('readonly array input with nested object', async () => {
+    const result = await all([{ a: 1 }, Promise.resolve({ b: 2 })])
+
+    expectTypeOf(result).toEqualTypeOf<[{ a: number }, { b: number }]>()
+  })
+
   test('readonly object input of promises, promise-like objects, and non-promises', async () => {
     const result = await all({
       a: Promise.resolve(1 as const),

--- a/tests/async/all.test-d.ts
+++ b/tests/async/all.test-d.ts
@@ -1,0 +1,71 @@
+import { all } from 'radashi'
+
+describe('all', () => {
+  test('array input', async () => {
+    const result = await all([] as Promise<number>[])
+    expectTypeOf(result).toEqualTypeOf<number[]>()
+  })
+
+  test('object input', async () => {
+    const result = await all({} as Record<string, Promise<number>>)
+    expectTypeOf(result).toEqualTypeOf<Record<string, number>>()
+  })
+
+  test('readonly array input of promises, promise-like objects, and non-promises', async () => {
+    const result = await all([
+      Promise.resolve(1 as const),
+      new Thenable(2 as const),
+      3,
+    ] as const)
+
+    expectTypeOf(result).toEqualTypeOf<[1, 2, 3]>()
+  })
+
+  test('readonly object input of promises, promise-like objects, and non-promises', async () => {
+    const result = await all({
+      a: Promise.resolve(1 as const),
+      b: new Thenable(2 as const),
+      c: 3,
+    } as const)
+
+    expectTypeOf(result).toEqualTypeOf<{
+      a: 1
+      b: 2
+      c: 3
+    }>()
+  })
+
+  test('array input with nested promise', async () => {
+    const result = await all([[Promise.resolve(1 as const)] as const])
+
+    // Nested promises are not unwrapped.
+    expectTypeOf(result).toEqualTypeOf<[readonly [Promise<1>]]>()
+  })
+
+  test('object input with nested promise', async () => {
+    const result = await all({
+      a: { b: Promise.resolve(1 as const) },
+    })
+
+    // Nested promises are not unwrapped.
+    expectTypeOf(result).toEqualTypeOf<{ a: { b: Promise<1> } }>()
+  })
+})
+
+class Thenable<T> implements PromiseLike<T> {
+  constructor(private value: T) {}
+
+  // biome-ignore lint/suspicious/noThenProperty:
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?:
+      | ((value: T) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?:
+      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(this.value).then(onfulfilled, onrejected)
+  }
+}


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary

<!-- Describe what the change does and why it should be merged. -->
Make `all` less strict both at the type level and at runtime, making it closer to `Promise.all` behavior.

1. Values are not required to have a `then` method (e.g. promises and promise-like objects). If no `then` method exists, the value is used as-is.
2. I've made the following performance improvements:
  - Avoid heap allocations where possible. Previously, `all` would create one array per promise when called with an array of promises. In all cases, `all` would create an additional object upon the resolution of each promise. Upon completion, `all` would filter the results, which allocated another array, and map the filtered results afterwards, allocating yet another array. For each promise, `all` would allocate two functions (a `then` callback and a `catch` callback).
  - Stop creating an empty object `{}` and using `Array#reduce` to populate it. Instead, use spread syntax on the input object, thereby reusing the input object's V8 “hidden class”. Then gradually assign the resolved values to the output object.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/all.ts` | 559 | -66 (-11%) |

[^1337]: Function size includes the `import` dependencies of the function.



