### PR TITLE
feat: add `breakFunc` argument to use `break` in the “map” function

### DIFF
--- a/docs/async/map.mdx
+++ b/docs/async/map.mdx
@@ -19,4 +19,14 @@ const api = {
 const users = await _.map(userIds, async userId => {
   return await api.users.find(userId)
 }) // [true, true, false, false]
+
+const users = await _.map(
+  userIds,
+  async userId => {
+    return await api.users.find(userId)
+  },
+  user => {
+    return user === 3
+  },
+) // [true, true]
 ```

--- a/src/async/map.ts
+++ b/src/async/map.ts
@@ -16,6 +16,7 @@
 export async function map<T, K>(
   array: readonly T[],
   asyncMapFunc: (item: T, index: number) => Promise<K>,
+  breakFunc?: (result: Awaited<K>, item: T, index: number) => boolean,
 ): Promise<K[]> {
   if (!array) {
     return []
@@ -23,7 +24,11 @@ export async function map<T, K>(
   const result = []
   let index = 0
   for (const value of array) {
-    const newValue = await asyncMapFunc(value, index++)
+    const newValue = await asyncMapFunc(value, index)
+
+    if (breakFunc && breakFunc(newValue, value, index)) break
+
+    index++
     result.push(newValue)
   }
   return result

--- a/tests/async/map.test.ts
+++ b/tests/async/map.test.ts
@@ -27,4 +27,14 @@ describe('map', () => {
     const result = await _.map(array, mapper)
     expect(result).toEqual(['a0', 'b1', 'c2', 'd3'])
   })
+
+  test('returns result with break', async () => {
+    const array = ['a', 'b', 'c', 'd']
+    const mapper = async (l: string, index: number) => `${l}${index}`
+    const breakFunc = (result: string, item: string, index: number) =>{
+     return item === 'c' && result === `${item}${index}`
+    }
+    const result = await _.map(array, mapper, breakFunc)
+    expect(result).toEqual(['a0', 'b1'])
+  })
 })


### PR DESCRIPTION
> [!TIP]
> The owner of this PR can publish a _preview release_ by commenting `/publish` in this PR. Afterwards, anyone can try it out by running `pnpm add radashi@pr<PR_NUMBER>`.

## Summary
This PR adds the `breakFunc` argument to use `break` in the “map” function.

## Related issue, if any:

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/map.ts` | 149 | +25 (+20%) |

[^1337]: Function size includes the `import` dependencies of the function.



