### PR TITLE
chore(renovate): be more conservative with dependency upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "all dependencies",
-      "matchPackageNames": ["*"],
+      "groupSlug": "all",
       "matchConfidence": "high"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,13 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "minimumReleaseAge": "30 days",
   "dependencyDashboard": true,
   "packageRules": [
     {
       "groupName": "all dependencies",
-      "groupSlug": "all",
-      "matchPackageNames": ["*"]
+      "matchPackageNames": ["*"],
+      "matchConfidence": "high"
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     {
       "groupName": "all dependencies",
       "groupSlug": "all",
+      "matchPackageNames": ["*"],
       "matchConfidence": "high"
     }
   ],


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Due to a large amount of updates, in the [dependency update PR](https://github.com/radashi-org/radashi/pull/282), I think it makes sense to configure the dependency bot to only recommend [updating dependencies that are more than 30](https://docs.renovatebot.com/configuration-options/#minimumreleaseage) days old and that have a [high level of confidence.](https://docs.renovatebot.com/merge-confidence/#confidence-levels-and-their-meaning)

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->
No

<!-- If yes, describe the impact and migration path for existing applications. -->
