### PR TITLE
fix(types): let `map` callback return a `PromiseLike` object

### DIFF
--- a/src/async/map.ts
+++ b/src/async/map.ts
@@ -15,7 +15,7 @@
  */
 export async function map<T, K>(
   array: readonly T[],
-  asyncMapFunc: (item: T, index: number) => Promise<K>,
+  asyncMapFunc: (item: T, index: number) => PromiseLike<K>,
 ): Promise<K[]> {
   if (!array) {
     return []


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
Since we're simply using `await` on the callback result, returning a `PromiseLike` is totally fine. Therefore, the type definitions should reflect that.


## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
