### PR TITLE
feat: add `withSemaphore` function

### DIFF
--- a/docs/async/withSemaphore.mdx
+++ b/docs/async/withSemaphore.mdx
@@ -1,0 +1,14 @@
+---
+title: withSemaphore
+description: desc
+---
+
+### Usage
+
+Does a thing. Returns a value.
+
+```ts
+import * as _ from 'radashi'
+
+_.withSemaphore()
+```

--- a/docs/async/withSemaphore.mdx
+++ b/docs/async/withSemaphore.mdx
@@ -1,14 +1,65 @@
 ---
 title: withSemaphore
-description: desc
+description: A synchronization primitive for limiting concurrent usage
 ---
 
 ### Usage
 
-Does a thing. Returns a value.
+Creates a [semaphore-protected](https://en.wikipedia.org/wiki/Semaphore_(programming)) async function that limits concurrent execution to a specified number of active uses.
+Additional calls will wait for previous executions to complete.
 
 ```ts
 import * as _ from 'radashi'
 
-_.withSemaphore()
+const exclusiveFn =_.withSemaphore(2, async () => {
+  // Do stuff
+})
+
+exclusiveFn() // run immediatly
+exclusiveFn() // run immediatly
+exclusiveFn() // wait until semaphore is released
+```
+
+#### Using with task based functions
+
+Execution function can be passed as a task parameter and ignored at the semaphore creation.
+
+```ts
+import * as _ from 'radashi'
+
+const exclusiveFn =_.withSemaphore({ capacity: 2 })
+
+exclusiveFn(async (permit) => {
+  // Do stuff
+})
+```
+
+#### Weighted tasks
+
+Each task can require a specific weight from a semaphore. In this example two tasks each weighted with 2 from
+a semaphore with a capacity of 2. As a result they are mutually exclusive.
+
+```ts
+import * as _ from 'radashi'
+
+const exclusiveFn =_.withSemaphore({ capacity: 2 })
+
+exclusiveFn({ weight: 2 }, async (permit) => { }) // run immediatly
+exclusiveFn({ weight: 2 }, async (permit) => { }) // wait until semaphore is released
+```
+
+### Manual lock management
+
+The semaphore can be manually acquired and released for fine-grained control over locking behavior.
+
+```ts
+import * as _ from 'radashi'
+
+const semaphore =_.withSemaphore({ capacity: 2 })
+
+const permit = await semaphore.acquire()
+
+// Do stuff
+
+permit.release()
 ```

--- a/src/async/withSemaphore.ts
+++ b/src/async/withSemaphore.ts
@@ -21,36 +21,36 @@ export interface Semaphore {
 }
 
 /**
- * Does a thing.
+ * Creates a semaphore-protected async function that limits concurrent execution to a specified number of active uses.
  *
  * @see https://radashi.js.org/reference/async/withSemaphore
  * @example
  * ```ts
- * const limitedFn = withSemaphore(1)
+ * const limitedFn = withSemaphore(2)
  * limitedFn(() => ...)
  * ```
  */
 export function withSemaphore(capacity: number): ExclusiveFn;
 
 /**
- * Does a thing.
+ * Creates a semaphore-protected async function that limits concurrent execution to a specified number of active uses.
  *
  * @see https://radashi.js.org/reference/async/withSemaphore
  * @example
  * ```ts
- * const limitedFn = withSemaphore({ capacity: 1 })
+ * const limitedFn = withSemaphore({ capacity: 2 })
  * limitedFn(() => ...)
  * ```
  */
 export function withSemaphore(options: WithSemaphoreOptions): ExclusiveFn;
 
 /**
- * Does a thing.
+ * Creates a semaphore-protected async function that limits concurrent execution to a specified number of active uses.
  *
  * @see https://radashi.js.org/reference/async/withSemaphore
  * @example
  * ```ts
- * const limitedFn = withSemaphore(1, () => ...)
+ * const limitedFn = withSemaphore(2, () => ...)
  * limitedFn()
  * limitedFn(() => ...)
  * ```
@@ -58,12 +58,12 @@ export function withSemaphore(options: WithSemaphoreOptions): ExclusiveFn;
 export function withSemaphore<T>(capacity: number, fn: AnyFn<T>): PrebuiltExclusiveFn<T>;
 
 /**
- * Does a thing.
+ * Creates a semaphore-protected async function that limits concurrent execution to a specified number of active uses.
  *
  * @see https://radashi.js.org/reference/async/withSemaphore
  * @example
  * ```ts
- * const limitedFn = withSemaphore({ capacity: 1 }, () => ...)
+ * const limitedFn = withSemaphore({ capacity: 2 }, () => ...)
  * limitedFn()
  * limitedFn(() => ...)
  * ```

--- a/src/async/withSemaphore.ts
+++ b/src/async/withSemaphore.ts
@@ -1,0 +1,10 @@
+/**
+ * Does a thing.
+ *
+ * @see https://radashi.js.org/reference/async/withSemaphore
+ * @example
+ * ```ts
+ * withSemaphore()
+ * ```
+ */
+export function withSemaphore(): void { }

--- a/src/async/withSemaphore.ts
+++ b/src/async/withSemaphore.ts
@@ -1,10 +1,175 @@
+import { once } from "radashi";
+
+type AnyFn<T = unknown> = (permit: Permit) => Promise<T>
+
+export interface Permit {
+  weight: number;
+  /** Currently locked weight, including this permit */
+  running: number;
+  isAcquired: boolean;
+  release: () => void;
+}
+
+export interface WithSemaphoreOptions {
+  capacity: number;
+}
+
+export interface Semaphore {
+  getRunning(): number;
+  acquire(weight?: number): Promise<Permit>;
+  release(weight?: number): void;
+}
+
 /**
  * Does a thing.
  *
  * @see https://radashi.js.org/reference/async/withSemaphore
  * @example
  * ```ts
- * withSemaphore()
+ * const limitedFn = withSemaphore(1)
+ * limitedFn(() => ...)
  * ```
  */
-export function withSemaphore(): void { }
+export function withSemaphore(capacity: number): ExclusiveFn;
+
+/**
+ * Does a thing.
+ *
+ * @see https://radashi.js.org/reference/async/withSemaphore
+ * @example
+ * ```ts
+ * const limitedFn = withSemaphore({ capacity: 1 })
+ * limitedFn(() => ...)
+ * ```
+ */
+export function withSemaphore(options: WithSemaphoreOptions): ExclusiveFn;
+
+/**
+ * Does a thing.
+ *
+ * @see https://radashi.js.org/reference/async/withSemaphore
+ * @example
+ * ```ts
+ * const limitedFn = withSemaphore(1, () => ...)
+ * limitedFn()
+ * limitedFn(() => ...)
+ * ```
+ */
+export function withSemaphore<T>(capacity: number, fn: AnyFn<T>): PrebuiltExclusiveFn<T>;
+
+/**
+ * Does a thing.
+ *
+ * @see https://radashi.js.org/reference/async/withSemaphore
+ * @example
+ * ```ts
+ * const limitedFn = withSemaphore({ capacity: 1 }, () => ...)
+ * limitedFn()
+ * limitedFn(() => ...)
+ * ```
+ */
+export function withSemaphore<T>(options: WithSemaphoreOptions, fn: AnyFn<T>): PrebuiltExclusiveFn<T>;
+export function withSemaphore(optionsOrCapacity: number | WithSemaphoreOptions, baseFn?: AnyFn): PrebuiltExclusiveFn<unknown> {
+  const options = useOptions(optionsOrCapacity);
+  if (options.capacity < 1) throw new Error(`invalid capacity ${options.capacity}: must be positive`);
+
+  const queue: QueuedTask[] = [];
+  let running = 0;
+
+  function _dispatch() {
+    while (queue.length > 0 && running < options.capacity) {
+      const task = queue.shift()!;
+      running += task.weight;
+      task.resolve(_createPermit(task.weight));
+    }
+  }
+
+  function _createPermit(weight: number): Permit {
+    let isAcquired = true;
+
+    return {
+      get weight() { return weight },
+      get isAcquired() { return isAcquired },
+      get running() { return running },
+      release: once(() => {
+        release(weight)
+        isAcquired = false;
+      })
+    }
+  }
+
+  function release(weight = 1) {
+    if (weight < 1) throw new Error(`invalid weight ${weight}: must be positive`);
+
+    running -= weight;
+    _dispatch();
+  }
+
+  function acquire(weight = 1) {
+    if (weight < 1) throw new Error(`invalid weight ${weight}: must be positive`);
+    if (weight > options.capacity) throw new Error(`invalid weight ${weight}: must be lower than or equal capacity ${options.capacity}`);
+
+    return new Promise<Permit>((resolve, reject) => {
+      queue.push({ resolve, weight });
+      _dispatch();
+    });
+  }
+
+  async function runExclusive(optionsOrWeightOrFn?: number | ExclusiveOptions | AnyFn, innerFn?: AnyFn): Promise<unknown> {
+    const options = typeof optionsOrWeightOrFn === "function" ? {} : useExclusiveFnOptions(optionsOrWeightOrFn);
+    const fn = (typeof optionsOrWeightOrFn === "function" ? optionsOrWeightOrFn : innerFn) ?? baseFn;
+    if (!fn) throw new Error(`invalid execution: function is required`);
+
+    const permit = await acquire(options.weight)
+
+    try {
+      return await fn(permit);
+    } finally {
+      permit.release();
+    }
+  }
+
+  runExclusive.acquire = acquire;
+  runExclusive.release = release;
+  runExclusive.getRunning = () => running;
+
+  return runExclusive;
+}
+
+function useOptions(optionsOrCapacity: number | WithSemaphoreOptions): WithSemaphoreOptions {
+  if (typeof optionsOrCapacity === "number") {
+    return { capacity: optionsOrCapacity };
+  }
+
+  return optionsOrCapacity;
+}
+
+function useExclusiveFnOptions(optionsOrWeight?: number | ExclusiveOptions): ExclusiveOptions {
+  if (typeof optionsOrWeight === "number") {
+    return { weight: optionsOrWeight };
+  }
+
+  return optionsOrWeight ?? {};
+}
+
+
+type QueuedTask = {
+  weight: number;
+  resolve: (permit: Permit) => void;
+};
+
+
+interface ExclusiveOptions {
+  weight?: number;
+}
+
+interface ExclusiveFn extends Semaphore {
+  <T>(fn: AnyFn<T>): Promise<T>;
+  <T>(options: ExclusiveOptions, fn: AnyFn<T>): Promise<T>;
+  <T>(weight: number, fn: AnyFn<T>): Promise<T>;
+}
+
+interface PrebuiltExclusiveFn<T> extends ExclusiveFn {
+  (options: ExclusiveOptions): Promise<T>;
+  (weight?: number): Promise<T>;
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -43,6 +43,7 @@ export * from './async/timeout.ts'
 export * from './async/TimeoutError.ts'
 export * from './async/tryit.ts'
 export * from './async/withResolvers.ts'
+export * from './async/withSemaphore.ts'
 
 export * from './curry/callable.ts'
 export * from './curry/chain.ts'

--- a/tests/async/withSemaphore.test.ts
+++ b/tests/async/withSemaphore.test.ts
@@ -1,0 +1,7 @@
+import * as _ from 'radashi'
+
+describe('withSemaphore', () => {
+  test('does a thing', () => {
+    expect(_.withSemaphore()).toBe(undefined)
+  })
+})

--- a/tests/async/withSemaphore.test.ts
+++ b/tests/async/withSemaphore.test.ts
@@ -1,7 +1,127 @@
 import * as _ from 'radashi'
 
 describe('withSemaphore', () => {
-  test('does a thing', () => {
-    expect(_.withSemaphore()).toBe(undefined)
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('does not blocked while the semaphore has not reached zero', async () => {
+    const values: number[] = [];
+    const exclusive = _.withSemaphore(2)
+
+    exclusive(async () => { values.push(1) })
+    exclusive(async () => { values.push(2) })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(values).toEqual([1, 2])
+  })
+
+  test('does blocked while the semaphore has reached zero', async () => {
+    const values: number[][] = [];
+    const exclusive = _.withSemaphore(2)
+    exclusive(async (permit) => {
+      await _.sleep(50)
+      values.push([1, permit.running])
+    })
+    exclusive(async (permit) => {
+      await _.sleep(100)
+      values.push([2, permit.running])
+    })
+    exclusive(async (permit) => {
+      await _.sleep(100)
+      values.push([3, permit.running])
+    })
+
+    await vi.advanceTimersByTimeAsync(51)
+    expect(values).toEqual([[1, 2]])
+
+    await vi.advanceTimersByTimeAsync(51)
+    expect(values).toEqual([[1, 2], [2, 2]])
+
+    await vi.advanceTimersByTimeAsync(51)
+    expect(values).toEqual([[1, 2], [2, 2], [3, 1]])
+  })
+
+  test('does weight the rexecution', async () => {
+    const values: number[][] = [];
+    const exclusive = _.withSemaphore(2)
+    exclusive(2, async (permit) => {
+      values.push([1, permit.running])
+    })
+    exclusive(2, async (permit) => {
+      values.push([2, permit.running])
+    })
+    exclusive(2, async (permit) => {
+      values.push([3, permit.running])
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(values).toEqual([[1, 2], [2, 2], [3, 2]])
+  })
+
+  test('handler failures does not affect the semaphore release', async () => {
+    const exclusive = _.withSemaphore(2, async () => {
+      throw new Error('boom')
+    })
+
+    await expect(exclusive()).rejects.toThrow('boom')
+
+    expect(exclusive.getRunning()).toEqual(0)
+  })
+
+  test('does expose manual lock management', async () => {
+    const values: number[][] = [];
+    const semaphore = _.withSemaphore(2)
+    const permit = await semaphore.acquire(2)
+    expect(permit.weight).toBe(2)
+
+    semaphore(async (permit) => {
+      values.push([1, permit.running])
+    })
+
+    expect(values).toEqual([])
+
+    permit.release()
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(values).toEqual([[1, 1]])
+  })
+
+  test('permit is released only once', async () => {
+    const semaphore = _.withSemaphore(2)
+    const permit = await semaphore.acquire(2)
+
+    expect(permit.isAcquired).toBe(true)
+    expect(semaphore.getRunning()).toBe(2)
+
+    permit.release()
+    expect(permit.isAcquired).toBe(false)
+    expect(semaphore.getRunning()).toBe(0)
+
+    permit.release()
+    expect(permit.isAcquired).toBe(false)
+    expect(semaphore.getRunning()).toBe(0)
+  })
+
+  test('signatures', () => {
+    expect(_.withSemaphore(1)).toBeDefined()
+    expect(_.withSemaphore(1, async () => { })).toBeDefined()
+    expect(_.withSemaphore({ capacity: 1 })).toBeDefined()
+    expect(_.withSemaphore({ capacity: 1 }, async () => { })).toBeDefined()
+  })
+
+  test('invalid options', async () => {
+    const semaphore = _.withSemaphore(2)
+    expect(() => _.withSemaphore(0)).toThrow(/invalid capacity 0: must be positive/)
+    expect(() => semaphore.acquire(0)).toThrow(/invalid weight 0: must be positive/)
+    expect(() => semaphore.acquire(5)).toThrow(/invalid weight 5: must be lower than or equal capacity 2/)
+    expect(() => semaphore.release(0)).toThrow(/invalid weight 0: must be positive/)
+    // @ts-expect-error should pass function
+    await expect(semaphore(1)).rejects.toThrow(/invalid execution: function is required/)
   })
 })


### PR DESCRIPTION
## Summary

Implements the `withSemaphore` function which creates a [semaphore](https://en.wikipedia.org/wiki/Semaphore_(programming))

## Related issue, if any:

[Related discussion](https://github.com/orgs/radashi-org/discussions/222#discussioncomment-10857745)

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

## In addition

I struggled to initialize the function via the radashi cli because of [`No radashi dependency found in package.json`](https://github.com/radashi-org/radashi-tools/blob/bf5cd05b7e6e88155fedbc8d78cd1fdad591dc1b/packages/radashi-helper/src/util/cloneRadashi.ts#L9) error. 

https://app.warp.dev/block/FMHVZF6RUhM2jAIiADsEUR