### PR TITLE
feat: `memo` separate key for reading and writing cached values

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -2,10 +2,8 @@ If you open a PR that introduces a new function, add it to the "New Functions" s
 
 The `####` headline should be short and descriptive of the new functionality. In the body of the section, include a link to the PR. You don't need to include a description of the change itself, as we will extract that from the documentation.
 
-## New Functions
-
-####
-
 ## New Features
 
-####
+#### dissociate `memo` chache read keys from set keys
+
+https://github.com/radashi-org/radashi/pull/333

--- a/docs/curry/memo.mdx
+++ b/docs/curry/memo.mdx
@@ -63,3 +63,32 @@ const beta = timestamp({ group: 'beta' })
 now === later // => true
 beta === now // => false
 ```
+
+You can optionally use a separate key for reading and writing cached values by providing a `setKey` function.
+This allows for more flexible cache management and sharing of cached values between different function calls.
+
+```ts
+const func = _.memo(
+  (arg: { id: string; withAdditionalStuff: boolean }) => {
+    if (arg.withAdditionalStuff) {
+      // do stuff
+    }
+
+    return arg.id
+  },
+  {
+    key: arg =>
+      arg.withAdditionalStuff
+        ? `${arg.id}_withAdditionalStuff`
+        : [`${arg.id}`, `${arg.id}_withAdditionalStuff`], // we also look for the shared key
+    setKey: arg =>
+      arg.withAdditionalStuff
+        ? [`${arg.id}`, `${arg.id}_withAdditionalStuff`] // we also set the shared key
+        : `${arg.id}`,
+  },
+)
+
+func({ id: '1', withAdditionalStuff: true })
+func({ id: '1', withAdditionalStuff: false })
+// func is executed once
+```

--- a/tests/curry/memo.test.ts
+++ b/tests/curry/memo.test.ts
@@ -7,6 +7,7 @@ describe('memo', () => {
     const resultB = func()
     expect(resultA).toBe(resultB)
   })
+
   test('uses key to identify unique calls', () => {
     const func = _.memo(
       (arg: { user: { id: string } }) => {
@@ -23,6 +24,32 @@ describe('memo', () => {
     expect(resultA).toBe(resultA2)
     expect(resultB).not.toBe(resultA)
   })
+
+  test('uses multiple keys to identify unique calls', () => {
+    const rawFn = vi.fn((arg: { id: string; withAdditionalStuff: boolean }) => {
+      if (arg.withAdditionalStuff) {
+        // do stuff
+      }
+
+      return arg.id
+    })
+
+    const func = _.memo(rawFn, {
+      key: arg =>
+        arg.withAdditionalStuff
+          ? `${arg.id}_withAdditionalStuff`
+          : [`${arg.id}`, `${arg.id}_withAdditionalStuff`], // we also look for the shared key
+      setKey: arg =>
+        arg.withAdditionalStuff
+          ? [`${arg.id}`, `${arg.id}_withAdditionalStuff`] // we also set the shared key
+          : `${arg.id}`,
+    })
+
+    func({ id: '1', withAdditionalStuff: true })
+    func({ id: '1', withAdditionalStuff: false })
+    expect(rawFn).toHaveBeenCalledTimes(1)
+  })
+
   test('calls function again when first value expires', async () => {
     vi.useFakeTimers()
     const func = _.memo(() => new Date().getTime(), {
@@ -33,6 +60,7 @@ describe('memo', () => {
     const resultB = func()
     expect(resultA).not.toBe(resultB)
   })
+
   test('does not call function again when first value has not expired', async () => {
     vi.useFakeTimers()
     const func = _.memo(() => new Date().getTime(), {

--- a/tests/curry/memo.test.ts
+++ b/tests/curry/memo.test.ts
@@ -48,6 +48,12 @@ describe('memo', () => {
     func({ id: '1', withAdditionalStuff: true })
     func({ id: '1', withAdditionalStuff: false })
     expect(rawFn).toHaveBeenCalledTimes(1)
+
+    rawFn.mockClear()
+
+    func({ id: '2', withAdditionalStuff: false })
+    func({ id: '2', withAdditionalStuff: true })
+    expect(rawFn).toHaveBeenCalledTimes(2)
   })
 
   test('calls function again when first value expires', async () => {


### PR DESCRIPTION
## Summary

You can optionally use a separate key for reading and writing cached values by providing a `setKey` function.
This allows for more flexible cache management and sharing of cached values between different function calls.

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [x] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/curry/memo.ts` | 573 | +266 (+87%) |

[^1337]: Function size includes the `import` dependencies of the function.



