### PR TITLE
feat: add `withCapacity` function

### DIFF
--- a/src/async/withCapacity.ts
+++ b/src/async/withCapacity.ts
@@ -1,0 +1,84 @@
+import { isFunction } from 'radashi'
+
+export function withCapacity<
+  T extends (...args: any[]) => Promise<any> = never,
+>(capacity: number, job?: T): WithCapacity<T> {
+  const pendingJobs: (() => void)[] = []
+
+  let capacityTaken = 0
+
+  const enqueue = async <T extends (...args: any[]) => Promise<any>>(
+    job: T,
+    weight: number,
+    args?: Parameters<T>,
+  ) => {
+    if (capacityTaken + weight > capacity) {
+      if (weight > capacity) {
+        throw new Error('Weight is greater than capacity')
+      }
+      return new Promise(resolve => {
+        pendingJobs.push(function run() {
+          if (capacityTaken + weight > capacity) {
+            pendingJobs.unshift(run)
+          } else {
+            resolve(enqueue(job, weight, args))
+          }
+        })
+      })
+    }
+    capacityTaken += weight
+    try {
+      return await (args ? job(...args) : job())
+    } finally {
+      capacityTaken -= weight
+      pendingJobs.shift()?.()
+    }
+  }
+
+  const apply: Function = job
+    ? (...args: Parameters<T>) => enqueue(job, 1, args)
+    : <T>(
+        arg: JobOptions | (() => Promise<T>),
+        job?: () => Promise<T>,
+      ): Promise<T> =>
+        isFunction(arg) ? enqueue(arg, 1) : enqueue(job!, arg.weight)
+
+  const queue = apply as WithCapacity<T>
+  queue.hasCapacity = (weight = 1) => capacityTaken + weight <= capacity
+  queue.clear = () => {
+    pendingJobs.length = 0
+  }
+  return queue
+}
+
+export type JobOptions = {
+  /**
+   * Jobs have a weight. This is the amount of capacity they consume.
+   */
+  weight: number
+}
+
+interface JobRunner {
+  <T>(options: JobOptions, job: () => Promise<T>): Promise<T>
+  <T>(job: () => Promise<T>): Promise<T>
+}
+
+export type WithCapacity<T extends (...args: any[]) => Promise<any>> = ([
+  T,
+] extends [never]
+  ? JobRunner
+  : T) & {
+  /**
+   * Check if the semaphore has capacity for a given weight.
+   *
+   * @param weight - The weight to check for. If not provided, the weight will
+   * be 1.
+   */
+  hasCapacity: (weight?: number) => boolean
+  /**
+   * Clear the queue. Note that this does not cancel any jobs that are already
+   * running. If you need to cancel running jobs, you should do so manually
+   * (e.g. by passing an `AbortSignal` to each job).
+   */
+  clear: () => void
+}


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
This is an alternative implementation of `withSemaphore` introduced by #331.

It's different in a few notable ways:
- Its name is `withCapacity` (on the fence about this, but I think it's less jargon-y than `withSemaphore` and that's probably a good thing)
- It's about 1/3 the size in bytes.
- Different methods
  - No manual `acquire`/`release` and I'm leaning toward that being a good thing, though I want to be sure I'm not overlooking an important use case (maybe @hugo082 can clarify this). *Side note:* Perhaps, in the future, we should consider adding “lower level” (i.e. more error prone, yet more control) variants as `class` implementations, which might be where the acquire/release paradigm feels more appropriate.
  - Instead of `getRunning(): number`, there's a `hasCapacity(weight?: number): boolean` method. I'm not sure what the use case is for getting the current number of locks, so I'm hoping @hugo082 can clarify.

### withMutex

This PR doesn't have a `withMutex` function, and I'm still on the fence about it being a good addition, since it's easy enough to use `withCapacity(1, …)` for the same behavior? More clarity on this would be great.

## Related issue, if any:

#331

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
