### PR TITLE
fix(parallel): avoid range error with empty array

### DIFF
--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -66,6 +66,10 @@ export async function parallel<T, K>(
   array: readonly T[],
   func: (item: T) => Promise<K>,
 ): Promise<K[]> {
+  if (array.length === 0) {
+    return []
+  }
+
   const work = array.map((item, index) => ({
     index,
     item,

--- a/src/async/parallel.ts
+++ b/src/async/parallel.ts
@@ -66,7 +66,7 @@ export async function parallel<T, K>(
   array: readonly T[],
   func: (item: T) => Promise<K>,
 ): Promise<K[]> {
-  if (array.length === 0) {
+  if (!array.length) {
     return []
   }
 

--- a/tests/async/parallel.test.ts
+++ b/tests/async/parallel.test.ts
@@ -134,4 +134,11 @@ describe('parallel', () => {
   test('limit defaults to array length if Infinity is passed', async () => {
     await testConcurrency(Number.POSITIVE_INFINITY, _.list(1, 3), [1, 2, 3])
   })
+
+  test('returns empty array for empty input', async () => {
+    const result = await _.parallel(1, [], async () => {
+      throw new Error('Should not be called')
+    })
+    expect(result).toEqual([])
+  })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
Passing an empty array to `parallel` resulted in a clamp [range error](https://github.com/radashi-org/radashi/blob/3426478b22002dd0c2ad3cd29c7602cc3f7d17a0/src/number/clamp.ts#L27).

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Fixes #336

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/parallel.ts` | 1723 | +25 (+1%) |

[^1337]: Function size includes the `import` dependencies of the function.



