### PR TITLE
fix(shuffle): correction to Fisher-Yates implementation

### DIFF
--- a/src/random/shuffle.ts
+++ b/src/random/shuffle.ts
@@ -38,11 +38,11 @@ export function shuffle<T>(
   random: (min: number, max: number) => number = _.random,
 ): T[] {
   const newArray = array.slice()
-  for (let idx = 0, randomIdx: number, item: T; idx < array.length; idx++) {
-    randomIdx = random(0, array.length - 1)
-    item = newArray[randomIdx]
-    newArray[randomIdx] = newArray[idx]
-    newArray[idx] = item
+  for (let idx = array.length - 1, randomIdx: number, item: T; idx > 0; idx--) {
+    randomIdx = random(0, idx)
+    item = newArray[idx]
+    newArray[idx] = newArray[randomIdx]
+    newArray[randomIdx] = item
   }
   return newArray
 }


### PR DESCRIPTION

## Summary

A bias observed while using the `shuffle` function led me to double-check the implementation.

I believe the current version of `shuffle` does not implement Fisher-Yates correctly, since it is picking random indices from the entire array length in the loop. 

The proper Fisher-Yates algorithm should only pick from the _unshuffled_ portion.

I am not a cryptographic analyst, but intuitively, picking random indices from the entire array length (rather than just the unshuffled portion) introduces statistical bias and breaks the randomness guarantee. Iterations can swap with any position, including ones we just shuffled, so we might "undo" or "re-shuffle" already shuffled elements.

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No.



## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/random/shuffle.ts` | 190 | -7 (-4%) |

[^1337]: Function size includes the `import` dependencies of the function.



