### PR TITLE
fix(reduce): align with native reduce behavior + perf improvements

### DIFF
--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -35,7 +35,8 @@ export async function reduce<T, K>(
     if (!array.length) {
       throw new TypeError('Reduce of empty array with no initial value')
     }
-    acc = array[indices.next().value] as any
+    acc = array[0] as any
+    indices.next()
   }
   for (const index of indices) {
     acc = await reducer(acc!, array[index], index)

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -13,17 +13,29 @@
  */
 export async function reduce<T, K>(
   array: readonly T[],
-  asyncReducer: (acc: K, item: T, index: number) => Promise<K>,
-  initValue?: K,
+  reducer: (acc: K, item: T, index: number) => Promise<K>,
+  initialValue: K,
+): Promise<K>
+export async function reduce<T, K>(
+  array: readonly T[],
+  reducer: (acc: K, item: T, index: number) => Promise<K>,
+): Promise<K>
+export async function reduce<T, K>(
+  array: readonly T[],
+  reducer: (acc: K, item: T, index: number) => Promise<K>,
+  initialValue?: K,
 ): Promise<K> {
-  const initProvided = initValue !== undefined
-  if (!initProvided && array?.length < 1) {
-    throw new Error('Cannot reduce empty array with no init value')
+  const indices = (array ??= []).keys()
+  let acc = initialValue
+  // biome-ignore lint/style/noArguments:
+  if (acc === undefined && arguments.length < 3) {
+    if (!array.length) {
+      throw new TypeError('Reduce of empty array with no initial value')
+    }
+    acc = indices.next().value
   }
-  const iter = initProvided ? array : array.slice(1)
-  let value: any = initProvided ? initValue : array[0]
-  for (const [i, item] of iter.entries()) {
-    value = await asyncReducer(value, item, i)
+  for (const index of indices) {
+    acc = await reducer(acc!, array[index], index)
   }
-  return value
+  return acc!
 }

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -35,7 +35,7 @@ export async function reduce<T, K>(
     if (!array.length) {
       throw new TypeError('Reduce of empty array with no initial value')
     }
-    acc = array[indices.next().value]
+    acc = array[indices.next().value] as any
   }
   for (const index of indices) {
     acc = await reducer(acc!, array[index], index)

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -25,7 +25,7 @@ export async function reduce<T, K>(
   reducer: (acc: K, item: T, index: number) => Promise<K>,
   initialValue?: K,
 ): Promise<K> {
-  if (array === undefined) {
+  if (!array) {
     array = []
   }
   const indices = array.keys()

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -25,7 +25,10 @@ export async function reduce<T, K>(
   reducer: (acc: K, item: T, index: number) => Promise<K>,
   initialValue?: K,
 ): Promise<K> {
-  const indices = (array ??= []).keys()
+  if (array === undefined) {
+    array = []
+  }
+  const indices = array.keys()
   let acc = initialValue
   // biome-ignore lint/style/noArguments:
   if (acc === undefined && arguments.length < 3) {

--- a/src/async/reduce.ts
+++ b/src/async/reduce.ts
@@ -32,7 +32,7 @@ export async function reduce<T, K>(
     if (!array.length) {
       throw new TypeError('Reduce of empty array with no initial value')
     }
-    acc = indices.next().value
+    acc = array[indices.next().value]
   }
   for (const index of indices) {
     acc = await reducer(acc!, array[index], index)

--- a/tests/async/reduce.test.ts
+++ b/tests/async/reduce.test.ts
@@ -3,21 +3,15 @@ import * as _ from 'radashi'
 const cast = <T = any[]>(value: any): T => value
 
 describe('asyncReduce', () => {
+  const numbers = [0, 1, 2, 3, 4]
+  const reducer = async (a: number, b: number): Promise<number> => {
+    return new Promise(res => res(a + b))
+  }
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
   test('returns result of reducer', async () => {
-    const numbers = [
-      0,
-      1,
-      2,
-      3,
-      4, // => 10
-    ]
-    const asyncSum = async (a: number, b: number): Promise<number> => {
-      return new Promise(res => res(a + b))
-    }
-    const result = await _.reduce<number, number>(numbers, asyncSum, 0)
+    const result = await _.reduce<number, number>(numbers, reducer, 0)
     expect(result).toBe(10)
   })
   test('passes correct indexes', async () => {
@@ -35,41 +29,18 @@ describe('asyncReduce', () => {
     const result = await _.reduce<string, number[]>(array, asyncSumIndex, [])
     expect(result).toEqual([0, 1, 2, 3, 4])
   })
-})
-
-describe('reduce/asyncReduceV2', () => {
-  const numbers = [0, 1, 2, 3, 4]
-  const reducer = async (a: number, b: number): Promise<number> => {
-    return new Promise(res => res(a + b))
-  }
-
-  beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-  })
-  test('calls asyncReduce', async () => {
-    const result = await _.reduce<number, number>(numbers, reducer, 0)
-    expect(result).toBe(10)
-  })
   test('uses first item in array when no init provided', async () => {
     const result = await _.reduce(numbers, reducer)
     expect(result).toBe(10)
   })
   test('throws on no init value and an empty array', async () => {
-    try {
-      await _.reduce([], reducer)
-    } catch (err) {
-      expect(err).not.toBeNull()
-      return
-    }
-    expect.fail('Expected error to be thrown')
+    await expect(async () => _.reduce([], reducer)).rejects.toThrowError(
+      'Reduce of empty array with no initial value',
+    )
   })
   test('throws on no init value and a null array input', async () => {
-    try {
-      await _.reduce(cast(null), reducer)
-    } catch (err) {
-      expect(err).not.toBeNull()
-      return
-    }
-    expect.fail('Expected error to be thrown')
+    await expect(async () =>
+      _.reduce(cast(null), reducer),
+    ).rejects.toThrowError('Reduce of empty array with no initial value')
   })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
Optimizations include:
- Avoid using `array.entries()` which allocates one array per index unnecessarily
- Avoid using `array.slice(1)` when no initial value is provided
- To achieve the above cases, use `array.keys()` and call its `next()` method if the first element is used as the initial value

Other improvements in this commit:
- Align the “empty array with no initial value” error message with `Array.prototype.reduce`
- Use `arguments.length` to properly check whether an initial value was passed



## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
Closes #340

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/async/reduce.ts` | 249 | +19 (+8%) |

[^1337]: Function size includes the `import` dependencies of the function.



