### PR TITLE
feat: add `inlineThrow` function

### DIFF
--- a/docs/function/inlineThrow.mdx
+++ b/docs/function/inlineThrow.mdx
@@ -1,0 +1,14 @@
+---
+title: inlineThrow
+description: Throw an error from inside an expression
+---
+
+### Usage
+
+Does a thing. Returns a value.
+
+```ts
+import * as _ from 'radashi'
+
+_.inlineThrow()
+```

--- a/src/function/inlineThrow.ts
+++ b/src/function/inlineThrow.ts
@@ -1,0 +1,13 @@
+/**
+ * Throw an error from inside an expression.
+ *
+ * @see https://radashi.js.org/reference/function/inlineThrow
+ * @example
+ * ```ts
+ * const myFunc = (n: number) =>
+ *   n !== 0 ? 1 / n : inlineThrow(new Error('Zero division'))
+ * ```
+ */
+export function inlineThrow(error: Error): never {
+  throw error
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -59,6 +59,7 @@ export * from './curry/throttle.ts'
 export * from './function/always.ts'
 export * from './function/castComparator.ts'
 export * from './function/castMapping.ts'
+export * from './function/inlineThrow.ts'
 export * from './function/noop.ts'
 
 export * from './number/clamp.ts'

--- a/tests/function/inlineThrow.test.ts
+++ b/tests/function/inlineThrow.test.ts
@@ -1,0 +1,7 @@
+import * as _ from 'radashi'
+
+describe('inlineThrow', () => {
+  test('does a thing', () => {
+    expect(_.inlineThrow()).toBe(undefined)
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
The `inlineThrow` function can throw an error from inside an expression, while the `throw` keyword is limited to statements.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
