### PR TITLE
fix: `isObject` type Inference for `function` and `object` parameters

### DIFF
--- a/src/typed/isObject.ts
+++ b/src/typed/isObject.ts
@@ -24,6 +24,6 @@ import { isTagged } from 'radashi'
  * ```
  * @version 12.1.0
  */
-export function isObject(value: unknown): value is object {
+export function isObject<T>(value: T): value is Exclude<T, Function> & object {
   return isTagged(value, '[object Object]')
 }

--- a/tests/typed/isObject.test.ts
+++ b/tests/typed/isObject.test.ts
@@ -38,4 +38,14 @@ describe('isObject', () => {
     const result = _.isObject([1, 2, 3])
     expect(result).toBeFalsy()
   })
+  test('correctly distinguishes between function and object in a union type', () => {
+    const returnSomething: () => (() => void) | { a: string } = () => ({ a: 'a' })
+    const something = returnSomething()
+
+    if (_.isObject(something)) {
+      expect(something).toEqual({ a: 'a' })
+    } else {
+      expect(typeof something).toBe('function')
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Enhances `isObject` type inference to correctly distinguish between functions and objects in union types.
Fixes an issue where else blocks inferred never instead of void. 

## Related issue, if any:

#257 

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

