### PR TITLE
feat!: remove default size from `cluster`

### DIFF
--- a/.github/next-major.md
+++ b/.github/next-major.md
@@ -4,6 +4,10 @@ The `####` headline should be short and descriptive of the breaking change. In t
 
 ## Breaking Changes
 
+#### Removed default size from `cluster` function
+
+- The `size` parameter is now required.
+
 #### Reworked `debounce` function
 
 - Continue debouncing (in future calls) after `cancel` is called. Previously, `cancel` would disable debouncing, so future calls would be immediate.

--- a/benchmarks/array/cluster.bench.ts
+++ b/benchmarks/array/cluster.bench.ts
@@ -1,9 +1,9 @@
 import * as _ from 'radashi'
 
 describe('cluster', () => {
-  bench('with default cluster size', () => {
+  bench('with cluster size of 2', () => {
     const list = [1, 1, 1, 1, 1, 1, 1, 1]
-    _.cluster(list)
+    _.cluster(list, 2)
   })
 
   bench('specified cluster size of 3', () => {

--- a/benchmarks/array/cluster.bench.ts
+++ b/benchmarks/array/cluster.bench.ts
@@ -1,13 +1,13 @@
 import * as _ from 'radashi'
 
 describe('cluster', () => {
-  bench('with cluster size of 2', () => {
-    const list = [1, 1, 1, 1, 1, 1, 1, 1]
+  bench('small array', () => {
+    const list = new Array(10).fill(1)
     _.cluster(list, 2)
   })
 
-  bench('specified cluster size of 3', () => {
-    const list = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2]
-    _.cluster(list, 3)
+  bench('large array', () => {
+    const list = new Array(10000).fill(1)
+    _.cluster(list, 4)
   })
 })

--- a/docs/array/cluster.mdx
+++ b/docs/array/cluster.mdx
@@ -6,6 +6,8 @@ since: 12.1.0
 
 ### Usage
 
+**Note:** The `size` parameter is now required.
+
 Given an array of items and a desired cluster size (`n`), returns an array
 of arrays. Each child array containing `n` (cluster size) items
 split as evenly as possible.

--- a/docs/array/cluster.mdx
+++ b/docs/array/cluster.mdx
@@ -1,16 +1,13 @@
 ---
 title: cluster
-description: Split a list into many lists of the given size
+description: Divides an array into many arrays of the given size
 since: 12.1.0
 ---
 
 ### Usage
 
-**Note:** The `size` parameter is now required.
-
-Given an array of items and a desired cluster size (`n`), returns an array
-of arrays. Each child array containing `n` (cluster size) items
-split as evenly as possible.
+Takes an array and divides it into many arrays of the given size. The last
+array may be smaller than the given size, if not enough items are left.
 
 ```ts
 import * as _ from 'radashi'

--- a/src/array/cluster.ts
+++ b/src/array/cluster.ts
@@ -9,7 +9,7 @@
  * ```
  * @version 12.1.0
  */
-export function cluster<T>(array: readonly T[], size = 2): T[][] {
+export function cluster<T>(array: readonly T[], size: number): T[][] {
   const clusters: T[][] = []
   for (let i = 0; i < array.length; i += size) {
     clusters.push(array.slice(i, i + size))

--- a/tests/array/cluster.test.ts
+++ b/tests/array/cluster.test.ts
@@ -3,12 +3,13 @@ import * as _ from 'radashi'
 describe('cluster', () => {
   test('returns an array of arrays', () => {
     const list = [1, 1, 1, 1, 1, 1, 1, 1]
-    const result = _.cluster(list)
+    const result = _.cluster(list, 2)
     const [a, b, c] = result
     expect(a).toEqual([1, 1])
     expect(b).toEqual([1, 1])
     expect(c).toEqual([1, 1])
   })
+
   test('returns remainder in final cluster', () => {
     const list = [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2]
     const result = _.cluster(list, 3)


### PR DESCRIPTION
## Summary

This PR removes the default size from the `cluster` function.

## Related issue, if any:

https://github.com/orgs/radashi-org/discussions/91

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [x] Release notes in [next-minor.md](.github/next-major.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->

The `size` parameter is now required when calling the `cluster` function. Existing applications will need to provide a `size` argument when calling the function.

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/cluster.ts` | 107 | -2 (-2%) |
| M | `src/async/reduce.ts` | 239 | +10 (+4%) |
| M | `src/string/trim.ts` | 135 | +4 (+3%) |
| M | `src/typed/isEmpty.ts` | 475 | +113 (+31%) |

[^1337]: Function size includes the `import` dependencies of the function.



