### PR TITLE
chore: update code blocks to use twoslash syntax in documentation

### DIFF
--- a/docs/array/alphabetical.mdx
+++ b/docs/array/alphabetical.mdx
@@ -13,7 +13,7 @@ sort in descending order instead of the default ascending order.
 
 For numerical sorting, see the [sort](./sort) function.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -35,6 +35,6 @@ const gods = [
   },
 ]
 
-_.alphabetical(gods, g => g.name) // => [Loki, Ra, Vishnu, Zeus]
-_.alphabetical(gods, g => g.name, 'desc') // => [Zeus, Vishnu, Ra, Loki]
+const alphabeticalByName = _.alphabetical(gods, g => g.name) // => [Loki, Ra, Vishnu, Zeus]
+const alphabeticalByNameDesc = _.alphabetical(gods, g => g.name, 'desc') // => [Zeus, Vishnu, Ra, Loki]
 ```

--- a/docs/array/boil.mdx
+++ b/docs/array/boil.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items return the final item that wins the comparison condition. Useful for more complicated min/max.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -26,6 +26,6 @@ const gods = [
   },
 ]
 
-_.boil(gods, (a, b) => (a.power > b.power ? a : b))
+const boilByPower = _.boil(gods, (a, b) => (a.power > b.power ? a : b))
 // => { name: 'Ra', power: 100 }
 ```

--- a/docs/array/cartesianProduct.mdx
+++ b/docs/array/cartesianProduct.mdx
@@ -11,7 +11,7 @@ The inputs are arrays, and the output is an array of arrays representing all
 possible combinations where the first element is from the first array, the second element
 is from the second array, and so on.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const colors = ['red', 'blue']

--- a/docs/array/castArray.mdx
+++ b/docs/array/castArray.mdx
@@ -8,10 +8,13 @@ since: 12.2.0
 
 The `castArray` function ensures that the input value is always returned as an array. If the input is already an array, it returns a shallow copy of the array. If the input is not an array, it wraps the input in a new array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-_.castArray(1) // => [1]
-_.castArray([1, 2, 3]) // => [1, 2, 3]
-_.castArray('hello') // => ['hello']
+const numberToArray = _.castArray(1) // => [1]
+const arrayToArray = _.castArray([1, 2, 3]) // => [1, 2, 3]
+const stringToArray = _.castArray('hello') // => ['hello']
+
+const nullToArray = _.castArray(null) // => [null]
+const undefinedToArray = _.castArray(undefined) // => [undefined]
 ```

--- a/docs/array/castArrayIfExists.mdx
+++ b/docs/array/castArrayIfExists.mdx
@@ -8,12 +8,13 @@ since: 12.2.0
 
 The `castArrayIfExists` function ensures that a non-nullish input value is always returned as an array. If the input is already an array, it returns a shallow copy of the array. If the input is not an array, it wraps the input in a new array. Nullish values (null or undefined) are passed through as is.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-_.castArrayIfExists(1) // => [1]
-_.castArrayIfExists([1, 2, 3]) // => [1, 2, 3]
-_.castArrayIfExists('hello') // => ['hello']
-_.castArrayIfExists(null) // => null
-_.castArrayIfExists(undefined) // => undefined
+const numberToArray = _.castArrayIfExists(1) // => [1]
+const arrayToArray = _.castArrayIfExists([1, 2, 3]) // => [1, 2, 3]
+const stringToArray = _.castArrayIfExists('hello') // => ['hello']
+
+const nullToArray = _.castArrayIfExists(null) // => null
+const undefinedToArray = _.castArrayIfExists(undefined) // => undefined
 ```

--- a/docs/array/cluster.mdx
+++ b/docs/array/cluster.mdx
@@ -10,7 +10,7 @@ Given an array of items and a desired cluster size (`n`), returns an array
 of arrays. Each child array containing `n` (cluster size) items
 split as evenly as possible.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -26,10 +26,10 @@ const gods = [
   'Athena',
 ]
 
-_.cluster(gods, 3)
+const clustered = _.cluster(gods, 3)
 // => [
-//   [ 'Ra', 'Zeus', 'Loki' ],
-//   [ 'Vishnu', 'Icarus', 'Osiris' ],
+//   ['Ra', 'Zeus', 'Loki'],
+//   ['Vishnu', 'Icarus', 'Osiris'],
 //   ['Thor', 'Apollo', 'Artemis'],
 //   ['Athena']
 // ]

--- a/docs/array/concat.mdx
+++ b/docs/array/concat.mdx
@@ -14,7 +14,7 @@ The `concat` function combines multiple values and arrays into a single array, w
 
 Other falsy values (e.g. `0`, `false`, `''`, `NaN`) are preserved.
 
-```ts
+```ts twoslash
 import { concat } from 'radashi'
 
 const result = concat('a', null, ['b', undefined], 'c')

--- a/docs/array/counting.mdx
+++ b/docs/array/counting.mdx
@@ -11,7 +11,7 @@ how each object should be identified. Returns an object where the keys
 are the id values the callback returned and each value is an integer
 telling how many times that id occurred.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -29,5 +29,5 @@ const gods = [
   },
 ]
 
-_.counting(gods, g => g.culture) // => { egypt: 1, greek: 2 }
+const countingByCulture = _.counting(gods, g => g.culture) // => { egypt: 1, greek: 2 }
 ```

--- a/docs/array/diff.mdx
+++ b/docs/array/diff.mdx
@@ -9,11 +9,11 @@ since: 12.1.0
 Given two arrays, returns an array of all items that exist in the first array
 but do not exist in the second array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const oldWorldGods = ['ra', 'zeus']
 const newWorldGods = ['vishnu', 'zeus']
 
-_.diff(oldWorldGods, newWorldGods) // => ['ra']
+const diff = _.diff(oldWorldGods, newWorldGods) // => ['ra']
 ```

--- a/docs/array/first.mdx
+++ b/docs/array/first.mdx
@@ -8,11 +8,11 @@ since: 12.1.0
 
 Given an array of items return the first item or a default value if no items exists.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = ['ra', 'loki', 'zeus']
 
-_.first(gods) // => 'ra'
-_.first([], 'vishnu') // => 'vishnu'
+const first = _.first(gods) // => 'ra'
+const firstDefault = _.first([], 'vishnu') // => 'vishnu'
 ```

--- a/docs/array/flat.mdx
+++ b/docs/array/flat.mdx
@@ -8,12 +8,12 @@ since: 12.1.0
 
 Given an array that contains many arrays, return a new array where all items from the children are present at the top level.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [['ra', 'loki'], ['zeus']]
 
-_.flat(gods) // => [ra, loki, zeus]
+const flat = _.flat(gods) // => [ra, loki, zeus]
 ```
 
 Note, `_.flat` is not recursive and will not flatten children of children of children ... of children. It will only flatten `T[][]` an array of arrays.

--- a/docs/array/fork.mdx
+++ b/docs/array/fork.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items and a condition, returns two arrays where the first contains all items that passed the condition and the second contains all items that failed the condition.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [

--- a/docs/array/group.mdx
+++ b/docs/array/group.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items, `group` will build up an object where each key is an array of the items that belong in that group.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [

--- a/docs/array/intersects.mdx
+++ b/docs/array/intersects.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given two arrays of items, returns true if any item exists in both arrays.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const oceanFish = ['tuna', 'tarpon']

--- a/docs/array/isArrayEqual.mdx
+++ b/docs/array/isArrayEqual.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 Checks if two arrays are equal in length and content using `Object.is` comparison.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isArrayEqual([1, 2, 3], [1, 2, 3])

--- a/docs/array/iterate.mdx
+++ b/docs/array/iterate.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 A bit like `forEach` meets `reduce`. Useful for running a function `n` number of times to generate a value. The `_.iterate` function takes a count (the number of times to run the callback), a callback function, and an initial value. The callback is run _count_ many times as a reducer and the accumulated value is then returned.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const value = _.iterate(

--- a/docs/array/last.mdx
+++ b/docs/array/last.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items return the last item or a default value if no items exists.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = ['marlin', 'bass', 'trout']

--- a/docs/array/list.mdx
+++ b/docs/array/list.mdx
@@ -12,11 +12,11 @@ The interface is identical to `range`.
 
 _A hat tip to Python's `range` functionality_
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.list(3) // [0, 1, 2, 3]
-_.list(0, 3) // [0, 1, 2, 3]
+_.list(1, 3) // [1, 2, 3]
 _.list(0, 3, 'y') // [y, y, y, y]
 _.list(0, 3, () => 'y') // [y, y, y, y]
 _.list(0, 3, i => i) // [0, 1, 2, 3]
@@ -31,33 +31,45 @@ _.list(0, 6, i => i, 2) // [0, 2, 4, 6]
 
 When givin a single argument, it's treated as the `size`. Returns a list with values from 0 to `size`.
 
-```ts
-_.list(3) // [0, 1, 2, 3]
+```ts twoslash
+import * as _ from 'radashi'
+
+// ---cut-before---
+const simpleList = _.list(3) // [0, 1, 2, 3]
 ```
 
 ### list(start, end)
 
 When given two arguments, they're treated as the `start` and `end`. Returns a list with values from `start` to `end`
 
-```ts
-_.list(2, 6) // [2, 3, 4, 5, 6]
+```ts twoslash
+import * as _ from 'radashi'
+
+// ---cut-before---
+const rangeList = _.list(2, 6) // [2, 3, 4, 5, 6]
 ```
 
 ### list(start, end, value)
 
 When given a third argument it's treated as the `value` to be used in the list. If the `value` is a function it will be called, with an index argument, to create every value.
 
-```ts
-_.list(2, 4, {}) // [{}, {}, {}]
-_.list(2, 4, null) // [null, null, null]
-_.list(2, 4, i => i) // [2, 3, 4]
+```ts twoslash
+import * as _ from 'radashi'
+
+// ---cut-before---
+const staticObjectList = _.list(2, 4, {}) // [{}, {}, {}]
+const staticValueList = _.list(2, 4, null) // [null, null, null]
+const functionList = _.list(2, 4, i => i) // [2, 3, 4]
 ```
 
 ### list(start, end, value, step)
 
 When given a fourth argument it's treated as the `step` size to skip when generating values from `start` to `end`.
 
-```ts
-_.list(2, 4, i => i, 2) // [2, 4]
-_.list(25, 100, i => i, 25) // [25, 50, 75, 100]
+```ts twoslash
+import * as _ from 'radashi'
+
+// ---cut-before---
+const steppedList = _.list(2, 4, i => i, 2) // [2, 4]
+const biggerSteppedList = _.list(25, 100, i => i, 25) // [25, 50, 75, 100]
 ```

--- a/docs/array/mapify.mdx
+++ b/docs/array/mapify.mdx
@@ -24,7 +24,7 @@ Returns a new `Map` object where keys and values are derived from the input arra
 
 #### Example
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [
@@ -40,10 +40,10 @@ const fish = [
     name: 'Trout',
     weight: 13,
   },
-]
+] as const
 
-_.mapify(fish, f => f.name) // => Map(3) {'Marlin' => { name: 'Marlin', weight: 105 }, 'Bass' => { name: 'Bass', weight: 8 }, 'Trout' => { name: 'Trout', weight: 13 }}
-_.mapify(
+const mappedByName = _.mapify(fish, f => f.name) // => Map(3) {'Marlin' => { name: 'Marlin', weight: 105 }, 'Bass' => { name: 'Bass', weight: 8 }, 'Trout' => { name: 'Trout', weight: 13 }}
+const mappedByNameAndWeight = _.mapify(
   fish,
   f => f.name,
   f => f.weight,

--- a/docs/array/merge.mdx
+++ b/docs/array/merge.mdx
@@ -9,7 +9,7 @@ since: 12.1.0
 Given two arrays of items and an identity function, returns the first
 list with all items from the second list where there was a match.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -30,5 +30,5 @@ const newGods = [
   },
 ]
 
-_.merge(gods, newGods, f => f.name) // => [{name: "Zeus" power: 100}, {name: "Ra", power: 97}]
+const mergedGods = _.merge(gods, newGods, f => f.name) // => [{name: "Zeus" power: 100}, {name: "Ra", power: 97}]
 ```

--- a/docs/array/objectify.mdx
+++ b/docs/array/objectify.mdx
@@ -25,7 +25,7 @@ Returns a new dictionary object where keys and values are derived from the input
 #### Example
 
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [
@@ -41,10 +41,10 @@ const fish = [
     name: 'Trout',
     weight: 13,
   },
-]
+] as const
 
-_.objectify(fish, f => f.name) // => { Marlin: [marlin object], Bass: [bass object], ... }
-_.objectify(
+const objectifiedByName = _.objectify(fish, f => f.name) // => { Marlin: [marlin object], Bass: [bass object], ... }
+const objectifiedByNameAndWeight = _.objectify(
   fish,
   f => f.name,
   f => f.weight,

--- a/docs/array/pluck.mdx
+++ b/docs/array/pluck.mdx
@@ -8,7 +8,7 @@ since: 12.5.0
 
 Pass in an array of objects and specify one or more keys to extract. The function returns a new array containing the extracted values (as an array of arrays). The input array is never mutated.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [
@@ -34,7 +34,7 @@ const allProps = _.pluck(gods)
 
 The `pluck` function can also accept mapping functions in addition to property names.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = [

--- a/docs/array/remove.mdx
+++ b/docs/array/remove.mdx
@@ -7,7 +7,7 @@ description: 'Filter an array by removing elements that satisfy a predicate func
 
 Pass in an array and a predicate function. The function returns a new array excluding elements that satisfy the predicate without mutating the original array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const numbers = [1, 2, 3, 4, 5]

--- a/docs/array/replace.mdx
+++ b/docs/array/replace.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items, replace the one that matches the given condition function. Only replaces the first match. Always returns a copy of the original array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [
@@ -32,5 +32,5 @@ const salmon = {
 }
 
 // read: replace fish with salmon where the name is Bass
-_.replace(fish, salmon, f => f.name === 'Bass') // => [marlin, salmon, trout]
+const replaced = _.replace(fish, salmon, f => f.name === 'Bass') // => [marlin, salmon, trout]
 ```

--- a/docs/array/replaceOrAppend.mdx
+++ b/docs/array/replaceOrAppend.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items, an item and an identity function, returns a new array with the item either replaced at the index of the existing item -- if it exists, else it is appended at the end.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [

--- a/docs/array/select.mdx
+++ b/docs/array/select.mdx
@@ -9,7 +9,7 @@ since: 12.1.0
 Applies a filter and a map operation at once and in one pass.
 If the filter is omitted, returns all non-nullish mapped values.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [

--- a/docs/array/selectFirst.mdx
+++ b/docs/array/selectFirst.mdx
@@ -16,7 +16,7 @@ This function is particularly useful when you need to find and transform an elem
 - Allows for separate mapping and condition functions
 - Returns `undefined` if no element satisfies the condition or if the array is empty/nullish
 
-```typescript
+```ts twoslash
 import * as _ from 'radashi'
 
 // Find the first even number and double it

--- a/docs/array/shift.mdx
+++ b/docs/array/shift.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a list of items, return an array that shift right n positions.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 _.shift(arr, 3) // => [7, 8, 9, 1, 2, 3, 4, 5, 6]

--- a/docs/array/sift.mdx
+++ b/docs/array/sift.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a list of items, return a new list with all items that are not falsy.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = ['salmon', null, false, NaN, 'sockeye', 'bass']

--- a/docs/array/sort.mdx
+++ b/docs/array/sort.mdx
@@ -10,7 +10,7 @@ Given an array, return a new array sorted either by the numerical property speci
 
 This function only supports numerical sorting. For alphabetic sorting, see the [alphabetical](./alphabetical) function.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [

--- a/docs/array/toggle.mdx
+++ b/docs/array/toggle.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 If the item matching the condition already exists in the list it will be removed. If it does not it will be added.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = ['ra', 'zeus', 'loki']
@@ -21,7 +21,7 @@ _.toggle(gods, 'vishnu') // => ['ra', 'zeus', 'loki', 'vishnu']
 
 You can pass an optional `toKey` function to determine the identity of non-primitive values. Helpful when working with more complex data types.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = { name: 'Ra' }
@@ -39,7 +39,7 @@ _.toggle(gods, vishnu, g => g.name) // => [ra, zeus, loki, vishnu]
 
 By default, toggle will append the item if it does not exist. If you need to prepend the item instead you can override the `strategy` in the options argument.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const gods = ['ra', 'zeus', 'loki']

--- a/docs/array/unique.mdx
+++ b/docs/array/unique.mdx
@@ -10,7 +10,7 @@ Given an array of items -- and optionally, a function to determine their identit
 
 The function preserves the original order of items, keeping the first occurence and omitting duplicates.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [

--- a/docs/array/unzip.mdx
+++ b/docs/array/unzip.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Creates an array of ungrouped elements, where each resulting array contains all elements at a specific index from the input arrays. The first array contains all first elements, the second array contains all second elements, and so on.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.unzip([

--- a/docs/array/zip.mdx
+++ b/docs/array/zip.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Creates an array of grouped elements, the first of which contains the first elements of the given arrays, the second of which contains the second elements of the given arrays, and so on.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const names = ['ra', 'zeus', 'loki']

--- a/docs/array/zipToObject.mdx
+++ b/docs/array/zipToObject.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Creates an object mapping the keys in the first array to their corresponding values in the second array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const names = ['ra', 'zeus', 'loki']

--- a/docs/async/all.mdx
+++ b/docs/async/all.mdx
@@ -12,8 +12,9 @@ errors are gathered and thrown in an AggregateError.
 
 Passing an array as an argument will return the resolved promise values as an array in the same order.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const [user] = await _.all([
   api.users.create(...),
@@ -26,8 +27,9 @@ const [user] = await _.all([
 
 Passing an object as an argument will return an object with the same keys and the values as the resolved promise values.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const { user } = await _.all({
   user: api.users.create(...),

--- a/docs/async/defer.mdx
+++ b/docs/async/defer.mdx
@@ -14,8 +14,9 @@ By default, if a cleanup function throws an error after the main function has th
 
 #### Clean up temporary files
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+import fs from 'fs/promises'
 
 // Placeholder functions
 const createBuildDir = async () => {
@@ -41,7 +42,10 @@ await _.defer(async cleanup => {
 
 #### Clean up resources in an API
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
+
 // Placeholder API
 const api = {
   org: {

--- a/docs/async/guard.mdx
+++ b/docs/async/guard.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 The `guard` function allows you to make an async function return `undefined` if it rejects. This is useful when you want to handle errors in a functional way, such as returning a default value.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const example = async () => {
@@ -23,7 +23,7 @@ const result = (await _.guard(example)) ?? []
 
 The 2nd argument to `guard` is an error predicate. If provided, the function will only return `undefined` if the error matches the predicate.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const DEFAULT_USER = { name: 'John Doe' }
@@ -49,7 +49,7 @@ const userB = await _.guard(() => fetchUser('oops'), isPlainError).catch(e => e)
 
 The `guard` function also works with synchronous functions.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 function example() {

--- a/docs/async/map.mdx
+++ b/docs/async/map.mdx
@@ -9,6 +9,8 @@ since: 12.1.0
 The `map` function is like `Array.prototype.map`, but it works with async functions. Only one item is processed at a time.
 
 ```ts
+import * as _ from 'radashi'
+
 const userIds = [1, 2, 3, 4]
 const api = {
   users: {

--- a/docs/async/parallel.mdx
+++ b/docs/async/parallel.mdx
@@ -8,10 +8,19 @@ since: 12.1.0
 
 The `parallel` function processes an array with an async callback. The first argument controls how many array items are processed at one time. Similar to `Promise.all`, an ordered array of results is returned.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+// ---cut-start---
+const api = {
+  users: {
+    find: async (id: number) => id < 3 ? { id, name: 'Alice' } : throw new Error('Not found'),
+  },
+}
+
+// ---cut-end---
 
 // Will run the find user async function 3 at a time
 // starting another request when one of the 3 is freed
@@ -28,8 +37,9 @@ Since v12.3.0, processing can be manually interrupted. Pass an `AbortController.
 
 When `parallel` is interrupted by the signal, it throws a `DOMException` (even in Node.js) with the message `This operation was aborted` and name `AbortError`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const abortController = new AbortController()
 const signal = abortController.signal
@@ -51,7 +61,8 @@ abortController.abort()
 
 Once the whole array has been processed, `parallel` will check for errors. If any errors occurred during processing, they are combined into a single `AggregateError`. The `AggregateError` has an `errors` array property which contains all the individual errors that were thrown.
 
-```ts
+```ts twoslash
+// @noErrors
 import * as _ from 'radashi'
 
 const userIds = [1, 2, 3]

--- a/docs/async/queueByKey.mdx
+++ b/docs/async/queueByKey.mdx
@@ -8,7 +8,7 @@ since: 12.6.0
 
 Wraps an asynchronous function to ensure that calls with the same key are queued and executed sequentially, while calls with different keys can run in parallel. This is useful for preventing race conditions when operations must not overlap for the same logical group (like user ID or resource ID).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const updateUser = async (userId: string, data: object) => {
@@ -40,7 +40,7 @@ queuedUpdate('user456', { name: 'Bob' })
 
 ### Advanced Example
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Database operations that must be serialized per table
@@ -71,7 +71,7 @@ queuedDbOp('orders', 'update', { id: 1, status: 'shipped' })
 
 Errors from the wrapped function are properly propagated to the caller, and the queue continues processing subsequent calls:
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const riskyOperation = async (id: string, shouldFail: boolean) => {

--- a/docs/async/reduce.mdx
+++ b/docs/async/reduce.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 A reduce that handles callback functions that return a promise.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const userIds = [1, 2, 3, 4]

--- a/docs/async/retry.mdx
+++ b/docs/async/retry.mdx
@@ -16,7 +16,7 @@ The `retry` function runs an async function and retries it if it fails. You can 
   - It receives the attempt number (starting with `1`) and returns the delay in milliseconds.
 - `signal` (v12.3.0+) allows you to pass an `AbortController.signal` to interrupt the retry operation
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const api = {
@@ -42,8 +42,22 @@ await _.retry({ backoff: i => 10 ** i }, api.users.list) // try 3 times with 10,
 
 If a `signal` is passed, the retry operation can be interrupted. When the signal is aborted, `retry`'s promise will reject with a `DOMException` (even in Node.js) with the message `This operation was aborted` and name `AbortError`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
+
+// ---cut-start---
+const api = {
+  users: {
+    async list() {
+      if (Math.random() < 0.5) {
+        throw new Error('Random error')
+      }
+      return []
+    },
+  },
+}
+// ---cut-end---
 
 const abortController = new AbortController()
 const signal = abortController.signal

--- a/docs/async/sleep.mdx
+++ b/docs/async/sleep.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 The `_.sleep` function allows you to delay in milliseconds.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 await _.sleep(2000) // => waits 2 seconds

--- a/docs/async/timeout.mdx
+++ b/docs/async/timeout.mdx
@@ -10,7 +10,7 @@ The `timeout` function creates a promise that rejects after a specified delay, w
 
 The default error is a `TimeoutError` with the message "Operation timed out".
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Rejects after 1 second with a default TimeoutError
@@ -27,7 +27,7 @@ await _.timeout(1000, () => new Error('Custom error'))
 
 One of the most useful ways to use `_.timeout` with `Promise.race` to set a timeout for an asynchronous operation.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const someAsyncTask = async () => {

--- a/docs/async/toResult.mdx
+++ b/docs/async/toResult.mdx
@@ -7,7 +7,7 @@ description: Converts a PromiseLike to a Promise<Result>
 
 Converts a `PromiseLike` to a `Promise<Result>`.
 
-```ts
+```ts twoslash
 import { toResult, Result } from 'radashi'
 
 const good = async (): Promise<number> => 1
@@ -26,7 +26,7 @@ const badResult = await toResult(bad())
 
 If the given promise throws a non-Error value, it will be rethrown. This ensures the `Result` always contains an `Error` value or undefined.
 
-```ts
+```ts twoslash
 // This won't catch the rejected promise, because it was
 // rejected with a string, not an Error.
 const res = await toResult(Promise.reject('test error'))
@@ -36,7 +36,7 @@ const res = await toResult(Promise.reject('test error'))
 
 This function won't catch synchronous errors. Only rejected promises are converted to an `Err`.
 
-```ts
+```ts twoslash
 function bad() {
   if (Math.random() > 0.5) {
     // ⚠️ This error won't be caught by `toResult`. To fix this, add

--- a/docs/async/tryit.mdx
+++ b/docs/async/tryit.mdx
@@ -10,8 +10,9 @@ Error-first callbacks were cool. Using mutable variables to hoist state when doi
 
 The `tryit` function let's you wrap a function to convert it to an error-first function. **Works for both async and sync functions.**
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const api = {
   users: {
@@ -21,17 +22,27 @@ const api = {
 const userIdA = 1
 const userIdB = 3
 
-const [err, user] = await _.tryit(api.users.find)(userId) // [null, { id: 1, name: 'Alice' }]
-const [err, user] = await _.tryit(api.users.find)(userIdB) // [Error('Not found'), undefined]
+const [errA, userA] = await _.tryit(api.users.find)(userIdA) // [null, { id: 1, name: 'Alice' }]
+const [errB, userB] = await _.tryit(api.users.find)(userIdB) // [Error('Not found'), undefined]
 ```
 
 ### Currying
 
 You can curry `tryit` if you like.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
+// ---cut-start---
+const api = {
+  users: {
+    find: async (id: number) => id < 3 ? { id, name: 'Alice' } : throw new Error('Not found'),
+  },
+}
+
+const userId = 1
+// ---cut-end---
 const findUser = _.tryit(api.users.find)
 
 const [err, user] = await findUser(userId)

--- a/docs/async/withResolvers.mdx
+++ b/docs/async/withResolvers.mdx
@@ -10,7 +10,7 @@ Creates a new promise and returns the resolve and reject functions along with th
 
 The ponyfill for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const { resolve, reject, promise } = _.withResolvers()

--- a/docs/curry/chain.mdx
+++ b/docs/curry/chain.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Chaining functions will cause them to execute one after another, passing the output from each function as the input to the next, returning the final output at the end of the chain.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const add = (y: number) => (x: number) => x + y
@@ -24,7 +24,7 @@ chained(7) // => 24
 
 ### Example
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 type Deity = {

--- a/docs/curry/compose.mdx
+++ b/docs/curry/compose.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 In a composition of functions, each function is given the next function as an argument and must call it to continue executing.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const useZero = (fn: any) => () => fn(0)

--- a/docs/curry/debounce.mdx
+++ b/docs/curry/debounce.mdx
@@ -10,7 +10,7 @@ The `debounce` function helps manage frequent function calls efficiently. It req
 
 If called again during this waiting period, it resets the timer. Your source function only runs after the full `delay` passes without interruption. This is useful for handling rapid events like keystrokes, ensuring your code responds only after a pause in activity.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const processData = (data: string) => {
@@ -33,7 +33,11 @@ setTimeout(() => {
 
 When the `leading` option is `true`, your callback is invoked immediately the very first time the debounced function is called. After that, the debounced function works as if `leading` was `false`.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @errors: 2353
+// ---cut-before---
+
 const myDebouncedFunc = _.debounce({ delay: 100, leading: true }, x => {
   console.log(x)
 })
@@ -52,7 +56,9 @@ The `cancel` method of the debounced function does two things:
 1. It cancels any pending invocations of the debounced function.
 2. It permanently disables the debouncing behavior. All future invocations of the debounced function will immediately invoke your callback.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
 const myDebouncedFunc = _.debounce({ delay: 100 }, x => {
   console.log(x)
 })

--- a/docs/curry/flip.mdx
+++ b/docs/curry/flip.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 
 Return a new function that swaps the only two arguments of the original function. This is most useful for reversing the order of a “comparator” (i.e. a function used for sorting).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const subtract = (a: number, b: number) => a - b

--- a/docs/curry/memo.mdx
+++ b/docs/curry/memo.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Wrap a function with memo to get a function back that automagically returns values that have already been calculated.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const timestamp = _.memo(() => Date.now())
@@ -23,7 +23,7 @@ now === later // => true
 
 You can optionally pass a `ttl` (time to live) that will expire memoized results. In versions prior to version 10, `ttl` had a value of 300 milliseconds if not specified.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const timestamp = _.memo(() => Date.now(), {
@@ -45,7 +45,9 @@ now === muchLater // => false
 
 You can optionally customize how values are stored when memoized.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
 const timestamp = _.memo(
   ({ group }: { group: string }) => {
     const ts = Date.now()

--- a/docs/curry/memoLastCall.mdx
+++ b/docs/curry/memoLastCall.mdx
@@ -9,7 +9,7 @@ Creates a memoized version of a function that caches only its most recent call.
 
 When the function is called with the same arguments as the previous call, it returns the cached result instead of recalculating. This is useful for optimizing expensive calculations when only the latest result needs to be cached, making it more memory-efficient than traditional memoization.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const expensiveCalculation = (x: number, y: number): number => {

--- a/docs/curry/once.mdx
+++ b/docs/curry/once.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Create a wrapper around a given function such that it executes at most once. Subsequent calls to the wrapped function return the result from the first execution, regardless of the arguments provided. This behavior is akin to memoization but specifically designed for single-use functions. The result of the first call is stored internally, allowing for efficient retrieval without recomputation.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fn = _.once(() => Math.random())
@@ -20,14 +20,14 @@ fn() // 0.5
 
 The `once.reset` function clears the stored result of a function that was previously wrapped with `once`. This allows the function to be executed again as if it were never called before, enabling dynamic reuse of the function with fresh computations.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-const fn = once(() => Math.random())
+const fn = _.once(() => Math.random())
 fn() // 0.5
 fn() // 0.5
 
-once.reset(fn)
+_.once.reset(fn)
 fn() // 0.3
 fn() // 0.3
 ```

--- a/docs/curry/partial.mdx
+++ b/docs/curry/partial.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Create a partial function by providing some -- or all -- of the arguments the given function needs.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const add = (a: number, b: number) => a + b

--- a/docs/curry/partob.mdx
+++ b/docs/curry/partob.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Modern javascript destructuring means a lot of developers, libraries, and frameworks are all opting for unary functions that take a single object that contains the arguments. The `_.partob` function let's you partob these unary functions.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const add = (props: { a: number; b: number }) => props.a + props.b

--- a/docs/curry/promiseChain.mdx
+++ b/docs/curry/promiseChain.mdx
@@ -8,7 +8,7 @@ since: 12.6.0
 
 Creates a function that executes multiple functions in the same order as they are passed in arguments. Each function may be synchronous or asynchronous. The result of each function is passed to the next function. The final result is returned as a `Promise`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const func1 = vi.fn((a, b) => a + b)

--- a/docs/curry/proxied.mdx
+++ b/docs/curry/proxied.mdx
@@ -8,8 +8,9 @@ since: 12.1.0
 
 Javascript's `Proxy` object is powerful but a bit awkward to use. The `_.proxied` function creates the `Proxy` for you and handles calling back to your handler when functions on the `Proxy` are called or properties are accessed.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 type Property = 'name' | 'size' | 'getLocation'
 

--- a/docs/curry/throttle.mdx
+++ b/docs/curry/throttle.mdx
@@ -20,8 +20,9 @@ The returned throttled function also includes these methods:
 - `isThrottled(): boolean`: To check if there's currently an active throttle
 - `trigger(...args): void`: To invoke the wrapped function without waiting for the next interval
 
-```typescript
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 // Throttle a scroll event handler
 const handleScroll = () => {

--- a/docs/function/always.mdx
+++ b/docs/function/always.mdx
@@ -8,8 +8,9 @@ since: 12.2.0
 
 Creates a function that always returns the same value, regardless of any arguments passed to it.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const alwaysTrue = _.always(true)
 
@@ -21,7 +22,11 @@ alwaysTrue(1, 2, 3) // true
 
 You can avoid using `always` if the value is a primitive (use `() => true` instead), but it can be useful if you need a function that always returns the same object reference, or if you want to memoize a calculation across multiple calls.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
+// ---cut-before---
+
 // Not memoized
 () => someCalculation()
 // Memoized

--- a/docs/function/castComparator.mdx
+++ b/docs/function/castComparator.mdx
@@ -13,8 +13,9 @@ The first argument of `castComparator` is called the `mapping`. This can be eith
 - **Function**: If `mapping` is a function, it maps the input values to a comparable value.
 - **Property Name**: If `mapping` is a property name, it maps the input values to a property of the input values with a comparable value.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const users = [
   { id: 1, firstName: 'Alice', lastName: 'Smith' },
@@ -27,7 +28,7 @@ users.sort(compareById)
 // [Alice, Drew, Charlie]
 
 const compareByFullName = _.castComparator(
-  user => `${user.firstName} ${user.lastName}`,
+  (user: typeof users[number]) => `${user.firstName} ${user.lastName}`,
   (a, b) => b.localeCompare(a),
 )
 users.sort(compareByFullName)
@@ -40,7 +41,10 @@ Optionally, you can pass a custom `compare` function that receives the mapped va
 
 A positive number means the “right value” is greater than the “left value”, a negative number means the “left value” is greater than the “right value”, and 0 means both values are equal.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
+
 const users = [
   { id: 1, firstName: 'Alice', lastName: 'Smith' },
   { id: 3, firstName: 'Charlie', lastName: 'Brown' },
@@ -48,7 +52,7 @@ const users = [
 ]
 
 const compareByFullName = _.castComparator(
-  user => `${user.firstName} ${user.lastName}`,
+  (user: typeof users[number]) => `${user.firstName} ${user.lastName}`,
   (a, b) => b.localeCompare(a),
 )
 

--- a/docs/function/castMapping.mdx
+++ b/docs/function/castMapping.mdx
@@ -14,7 +14,7 @@ The following types can be casted into a mapping function:
 2. **Property Name**: If the input is a property name, it returns a function that retrieves the value of that property from an object.
 3. **Nullish**: If the input is nullish (null or undefined), it returns a function that simply returns the input object itself.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Using a property name
@@ -36,8 +36,10 @@ identity({ any: 'value' }) // => { any: 'value' }
 
 This is the return type of `castMapping`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
+
 import type { CastMapping } from 'radashi'
 
 const data = { a: 1, b: '2' }
@@ -49,7 +51,9 @@ const mapper: CastMapping<typeof data, number> = _.castMapping(data => data.a)
 
 As you may have noticed in the previous example, the `MappedOutput` type is used to infer the type of the value returned by the mapping function.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
 import type { MappedOutput } from 'radashi'
 
 type Data = { a: number; b: string }
@@ -70,7 +74,8 @@ test<MappedOutput<undefined>>()
 
 You can use the `Mapping` type to accept a value that can be passed into `castMapping`.
 
-```ts
+```ts twoslash
+// @noErrors
 import * as _ from 'radashi'
 import type { Mapping, MappedOutput } from 'radashi'
 
@@ -84,7 +89,9 @@ function mapArray<T, TMapping extends Mapping<T>>(
 
 If you want a mapping to be optional, use the `OptionalMapping` type instead.
 
-```ts
+```ts twoslash
+// @noErrors
+import * as _ from 'radashi'
 import type { OptionalMapping, MappedOutput } from 'radashi'
 
 function mapArray<T, TMapping extends OptionalMapping<T>>(

--- a/docs/function/identity.mdx
+++ b/docs/function/identity.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 This is useful when you need to pass a function somewhere that simply returns the value it receives, without any modification.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.identity() // => undefined

--- a/docs/function/noop.mdx
+++ b/docs/function/noop.mdx
@@ -10,7 +10,7 @@ This is useful when you need to pass a function somewhere, but you don't care wh
 
 Since `noop` has a function signature of `() => undefined`, you will be warned by TypeScript if you pass it where a function is expected to return something different.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.noop() // => undefined

--- a/docs/number/clamp.mdx
+++ b/docs/number/clamp.mdx
@@ -16,18 +16,21 @@ range.
   maximum.
 - Otherwise, it returns the number itself.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-_.clamp(5, 1, 10) // 5
-_.clamp(0, 1, 10) // 1
-_.clamp(15, 1, 10) // 10
+const inRange = _.clamp(5, 1, 10) // 5
+const smaller = _.clamp(0, 1, 10) // 1
+const bigger = _.clamp(15, 1, 10) // 10
 ```
 
 #### Invalid ranges
 
 If the minimum is greater than the maximum, an error is thrown.
 
-```ts
-_.clamp(1, 10, 1) // throws Error
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
+
+const clamped = _.clamp(1, 10, 1) // throws Error
 ```

--- a/docs/number/parseDuration.mdx
+++ b/docs/number/parseDuration.mdx
@@ -8,7 +8,7 @@ since: 12.6.0
 
 Parse a human-readable duration string (like "1 hour", "2 seconds") into milliseconds.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.parseDuration('1 second') // => 1_000
@@ -20,7 +20,7 @@ _.parseDuration('-1h') // => -3_600_000
 
 You may use the `DurationParser` class instead, which is more efficient for repeated parsing.
 
-```ts
+```ts twoslash
 import { DurationParser } from 'radashi'
 
 const parser = new DurationParser()
@@ -45,7 +45,7 @@ Years and months are not supported by default, because both vary in length (e.g.
 
 You may pass additional units to the `parseDuration` function.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const customUnits = {

--- a/docs/number/parseQuantity.mdx
+++ b/docs/number/parseQuantity.mdx
@@ -9,7 +9,7 @@ since: 12.6.0
 Parse a quantity string like `"2 dollars"` into its numeric value. You must provide a
 unit conversion map, with optional short unit aliases.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const moneyUnits = {
@@ -34,7 +34,7 @@ _.parseQuantity('5$', moneyUnits)
 
 You may use the `QuantityParser` class instead, which is more efficient for repeated parsing.
 
-```ts
+```ts twoslash
 const moneyParser = new _.QuantityParser(moneyUnits)
 ```
 
@@ -45,7 +45,7 @@ you can use the [`parseDuration`](../parseDuration) function instead.
 
 You can subclass `QuantityParser` to create a parser for a specific unit.
 
-```ts
+```ts twoslash
 import { QuantityParser, type QuantityString } from 'radashi'
 
 export type DistanceUnit = keyof typeof DistanceParser.units
@@ -94,7 +94,7 @@ distanceParser.parse('1 meter') // => 1
 
 You may want to create a wrapper function to make it easier to use.
 
-```ts
+```ts twoslash
 import { DistanceParser, type DistanceString } from './DistanceParser'
 
 const parser = new DistanceParser()

--- a/docs/object/assign.mdx
+++ b/docs/object/assign.mdx
@@ -8,7 +8,8 @@ since: 12.1.0
 
 Merges two objects together recursively into a new object applying values from right to left. Recursion only applies to child object properties.
 
-```ts
+```ts twoslash
+// @errors: 2345
 import * as _ from 'radashi'
 
 const ra = {
@@ -16,6 +17,6 @@ const ra = {
   power: 100,
 }
 
-_.assign(ra, { name: 'Loki' })
+const merged = _.assign(ra, { name: 'Loki' })
 // => { name: Loki, power: 100 }
 ```

--- a/docs/object/clone.mdx
+++ b/docs/object/clone.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Creates a shallow copy of the given object/value.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/cloneDeep.mdx
+++ b/docs/object/cloneDeep.mdx
@@ -12,7 +12,7 @@ The default behavior aims to support the most popular use cases. See “Customiz
 
 By default, non-enumerable properties and computed properties are copied lossless-ly. Note that you can opt out of this behavior if you need better performance (see “Faster cloning” below).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const obj = { a: 1, b: { c: 2 } }
@@ -35,9 +35,9 @@ Also note that built-in, complex objects like `RegExp` and `Date` are still not 
 
 “Cloning strategies” control how certain object types are handled by `cloneDeep`. You can pass in a custom strategy, which may even be a partial strategy. Any undefined methods in your strategy will inherit the default logic. Your custom methods can return `null` to use the default logic, or they can return the received object to skip cloning.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
-
+// @errors: 2304 2322
 _.cloneDeep(obj, {
   // Clone arrays with default logic if they are not frozen.
   cloneArray: array => (Object.isFrozen(array) ? array : null),

--- a/docs/object/construct.mdx
+++ b/docs/object/construct.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 The opposite of crush, given an object that was crushed into key paths and values will return the original object reconstructed.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const flat = {
@@ -20,7 +20,7 @@ const flat = {
   'enemies.0.power': 12,
 }
 
-_.construct(flat)
+const reconstructed = _.construct(flat)
 // {
 //   name: 'ra',
 //   power: 100,

--- a/docs/object/crush.mdx
+++ b/docs/object/crush.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Flattens a deep object to a single dimension. The deep keys will be converted to a dot notation in the new object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {
@@ -26,7 +26,7 @@ const ra = {
   ],
 }
 
-_.crush(ra)
+const crushed = _.crush(ra)
 // {
 //   name: 'ra',
 //   power: 100,

--- a/docs/object/filterKey.mdx
+++ b/docs/object/filterKey.mdx
@@ -10,7 +10,7 @@ You have a utility function that is filtering an object's properties somehow. Us
 
 The `KeyFilter` type provided by Radashi is fundamental in taking advantage of the `filterKey` function. Be sure to use it to ensure type safety and maintainable code.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 function filterObject(obj: object, filter: _.KeyFilter) {

--- a/docs/object/get.mdx
+++ b/docs/object/get.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given any value and a select function to get the desired attribute, returns the desired value or a default value if the desired value couldn't be found.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = {

--- a/docs/object/getOrInsert.mdx
+++ b/docs/object/getOrInsert.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 Retrieves the current value for the key or inserts the provided value when the key does not exist.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const counts = new Map<string, number>()

--- a/docs/object/getOrInsertComputed.mdx
+++ b/docs/object/getOrInsertComputed.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 Computes and stores a value only when the key has no entry yet.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const counts = new Map<string, number>()
@@ -21,7 +21,7 @@ This function is most useful when the computed value is expensive to compute, e.
 
 You can use a `WeakMap` instead, if you'd like to associate the computed value with an object reference.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const values = new WeakMap<object, { count: number }>()

--- a/docs/object/invert.mdx
+++ b/docs/object/invert.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an object returns a new object with the keys and values reversed.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const powersByGod = {

--- a/docs/object/keys.mdx
+++ b/docs/object/keys.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an object, return all of it's keys and children's keys deeply as a flat string list.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/listify.mdx
+++ b/docs/object/listify.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an object and a mapping function, return an array with an item for each entry in the object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = {

--- a/docs/object/lowerize.mdx
+++ b/docs/object/lowerize.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Convert all keys in an object to lower case. Useful to standardize attribute key casing. For example, headers.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/mapEntries.mdx
+++ b/docs/object/mapEntries.mdx
@@ -11,7 +11,7 @@ to generate new entries. It's a `_.mapValues` and `_.mapKeys`
 in one. The `toEntry` callback function should return an array with
 two items `[key, value]` (a.k.a the new entry).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/mapKeys.mdx
+++ b/docs/object/mapKeys.mdx
@@ -9,7 +9,7 @@ since: 12.1.0
 Given an object and a `toKey` callback function, returns a new object with all the keys
 mapped through the `toKey` function. The callback is given both the key and value for each entry.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/mapValues.mdx
+++ b/docs/object/mapValues.mdx
@@ -9,7 +9,7 @@ since: 12.1.0
 Given an object and a `toValue` callback function, returns a new object with all the values
 mapped through the `toValue` function. The callback is given both the value and key for each entry.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/object/omit.mdx
+++ b/docs/object/omit.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an object and a list of keys in the object, returns a new object without any of the given keys.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = {

--- a/docs/object/pick.mdx
+++ b/docs/object/pick.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an object and a list of keys in the object, returns a new object with only the given keys.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = {
@@ -25,8 +25,9 @@ _.pick(fish, ['name', 'source']) // => { name, source }
 
 The `pick` function can also accept a predicate function as the filter argument. This allows for more complex filtering logic beyond simple key inclusion or exclusion.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const source = { a: 1, b: 2, c: 3, d: 4 }
 
@@ -44,9 +45,10 @@ When used with a predicate function, `pick` is potentially unsafe, because of pa
 
 :::
 
-```typescript
+```ts twoslash
 // Example demonstrating potential inaccuracy in `key` and `value` types within `_.pick` callback
 import * as _ from 'radashi'
+// @noErrors
 
 interface User {
   name: string

--- a/docs/object/set.mdx
+++ b/docs/object/set.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Opposite of get, dynamically set a nested value into an object using a key path. Does not modify the given initial object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.set({}, 'name', 'ra')

--- a/docs/object/shake.mdx
+++ b/docs/object/shake.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Returns a new object without the properties that are `undefined`. Note that non-enumerable keys are never shaken out.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const options = _.shake({
@@ -24,7 +24,7 @@ const options = _.shake({
 
 If you pass a function as the second argument, only the properties that return `false` will be included in the result.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const options = _.shake(

--- a/docs/object/traverse.mdx
+++ b/docs/object/traverse.mdx
@@ -10,8 +10,9 @@ Recursively visit each property of an object (or each element of an array) and i
 
 Traversal is performed in a depth-first manner. That means the deepest object will be visited before the last property of the root object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const root = { a: { b: 2 }, c: [1, 2] }
 
@@ -42,8 +43,9 @@ _.traverse(root, (value, key, parent, context) => {
 
 The `TraverseVisitor` type represents the function passed to `traverse` as its 2nd argument. If you ever need to declare a visitor separate from a `traverse` call, you can do so by declaring a function with this type signature.
 
-```ts
+```ts twoslash
 import { TraverseVisitor } from 'radashi'
+// @noErrors
 
 const visitor: TraverseVisitor = (value, key, parent, context) => {
   // ...
@@ -85,8 +87,9 @@ By default, non-enumerable properties and symbol properties are skipped. You can
 
 This example shows how `Reflect.ownKeys` can be used to include non-enumerable properties and symbol properties. Note that symbol properties are always traversed last when using `Reflect.ownKeys`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const symbol = Symbol('b')
 const root = { [symbol]: 1 }
@@ -110,8 +113,9 @@ By default, your `visitor` callback will never receive the object passed into `t
 
 When the root object is visited, the `key` will be `null`.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const root = { a: 1 }
 
@@ -133,8 +137,9 @@ _.traverse(
 
 If traversing plain objects and arrays isn't enough, try calling `traverse` from within another `traverse` callback like follows. This takes advantage of the fact that the root object is always traversed.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 // Note how we're using a named visitor function so it can reference itself.
 _.traverse(root, function visitor(value, key, parent, context, options) {
@@ -155,8 +160,9 @@ return _.traverse(root, visitor, null, context)
 
 Using the `TraverseContext::skip` method, you can prevent an object from being traversed. By calling `skip()` with no arguments, the current value won't be traversed.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const root = {
   a: { b: 1 },
@@ -179,8 +185,9 @@ _.traverse(root, (value, key, parent, context) => {
 
 You can pass any object to `skip()` to skip traversal of that object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
+// @noErrors
 
 const root = {
   a: {
@@ -209,7 +216,10 @@ _.traverse(root, (value, key, parent, context) => {
 
 If your `visitor` callback returns false, `traverse` will exit early and also return false. This is useful if you found what you wanted, so you don't need to traverse the rest of the objects.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
+
 let found = null
 _.traverse(root, value => {
   if (isWhatImLookingFor(value)) {
@@ -225,7 +235,10 @@ If your `visitor` callback returns a function, it will be called once `traverse`
 
 Your leave callback can return false to exit traversal early.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// @noErrors
+
 _.traverse({ arr: ['a', 'b'] }, (value, key) => {
   if (isArray(value)) {
     console.log('start of array')

--- a/docs/object/upperize.mdx
+++ b/docs/object/upperize.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Convert all keys in an object to upper case.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const ra = {

--- a/docs/oop/Semaphore.mdx
+++ b/docs/oop/Semaphore.mdx
@@ -8,7 +8,7 @@ since: 12.6.0
 
 A semaphore is a synchronization primitive that allows a limited number of concurrent operations to proceed.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(2)
@@ -20,7 +20,7 @@ permit.release()
 
 When the semaphore's capacity is reached, subsequent calls to `semaphore.acquire()` will block until a permit is released.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(1)
@@ -36,7 +36,7 @@ permit.release() // Releasing the permit allows blockingAcquire to resolve
 
 You can acquire permits with a specific `weight`. The semaphore's capacity is reduced by this weight. If the remaining capacity is less than the requested weight, the acquisition will block.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(4)
@@ -52,7 +52,7 @@ await semaphore.acquire({ weight: 1 })
 
 A permit can only be released once. Subsequent calls to `permit.release()` on the same permit instance will have no effect.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(1)
@@ -64,7 +64,7 @@ permit.release() // Has no effect
 
 The semaphore constructor requires a `maxCapacity` of more than 0. Acquiring a permit requires a `weight` of more than 0 and not exceeding the semaphore's `maxCapacity`. Invalid options will result in errors.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 // Invalid constructor
@@ -79,7 +79,7 @@ const semaphore = new Semaphore(2)
 
 You can abort a pending acquisition using an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) and its signal. If the signal is aborted before the permit is acquired, the acquire promise will reject with an `AbortError`.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(1)
@@ -97,7 +97,7 @@ await expect(acquirePromise).rejects.toThrow('This operation was aborted')
 
 You can reject all pending and future acquisition requests by calling `semaphore.reject()`. All promises returned by pending and future `acquire` calls will reject with the provided error.
 
-```ts
+```ts twoslash
 import { Semaphore } from 'radashi'
 
 const semaphore = new Semaphore(1)

--- a/docs/random/absoluteJitter.mdx
+++ b/docs/random/absoluteJitter.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 Add absolute noise to a base value by applying a random offset up to a maximum distance.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const base = 50

--- a/docs/random/draw.mdx
+++ b/docs/random/draw.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Draw, as in 'to draw a card from a deck', is used to get a random item from an array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = ['marlin', 'bass', 'trout']

--- a/docs/random/proportionalJitter.mdx
+++ b/docs/random/proportionalJitter.mdx
@@ -8,7 +8,7 @@ since: 12.7.0
 
 Add proportional noise to a base value by scaling a random offset with a given factor.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const base = 100

--- a/docs/random/random.mdx
+++ b/docs/random/random.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Generate a number within a range. This function is meant for utility use -- not cryptographic.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.random(0, 100) // => a random number between 0 and 100

--- a/docs/random/shuffle.mdx
+++ b/docs/random/shuffle.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Create a new array with the items of the given array but in a random order. The randomization is done using the [Fisher-Yates algorithm](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle), which is mathematically proven to be unbiased (i.e. all permutations are equally likely).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const fish = [
@@ -34,9 +34,12 @@ _.shuffle(fish)
 
 You can provide a custom random function to make the shuffle more or less random. The custom random function takes minimum and maximum values and returns a random number between them.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
+
 const array = [1, 2, 3, 4, 5]
-const customRandom = (min, max) =>
+const customRandom = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min
 _.shuffle(array, customRandom)
 ```

--- a/docs/random/uid.mdx
+++ b/docs/random/uid.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Generates a unique string with optional special characters.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.uid(7) // => UaOKdlW

--- a/docs/series/series.mdx
+++ b/docs/series/series.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 The series function allows you to work with ordered values from an enum or union type, such as a status, by returning an object for performing ordered logic.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 type Weekday = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday'
@@ -21,22 +21,22 @@ const weekdays = _.series<Weekday>([
   'friday',
 ])
 
-weekdays.min('tuesday', 'thursday') // => 'tuesday'
-weekdays.max('wednesday', 'monday') // => 'wednesday'
-weekdays.next('wednesday') // => 'thursday'
-weekdays.previous('tuesday') // => 'monday'
-weekdays.first() // => 'monday'
-weekdays.last() // => 'friday'
-weekdays.next('friday') // => null
-weekdays.next('friday', weekdays.first()) // => 'monday'
-weekdays.spin('monday', 3) // => 'thursday'
+const a = weekdays.min('tuesday', 'thursday') // => 'tuesday'
+const b = weekdays.max('wednesday', 'monday') // => 'wednesday'
+const c = weekdays.next('wednesday') // => 'thursday'
+const d = weekdays.previous('tuesday') // => 'monday'
+const e = weekdays.first() // => 'monday'
+const f = weekdays.last() // => 'friday'
+const g = weekdays.next('friday') // => null
+const h = weekdays.next('friday', weekdays.first()) // => 'monday'
+const i = weekdays.spin('monday', 3) // => 'thursday'
 ```
 
 ### Complex Data Types
 
 For objects, pass a second argument to `series`: a function that converts non-primitive values into an identity that can be checked for equality.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 type Weekday = {
@@ -54,6 +54,6 @@ const weekdays = _.series<Weekday>(
   w => w.day,
 )
 
-weekdays.next({ day: 'wednesday' }) // => { day: 'thursday' }
-weekdays.previous({ day: 'tuesday' }) // => { day: 'monday' }
+const a = weekdays.next({ day: 'wednesday' }) // => { day: 'thursday' }
+const b = weekdays.previous({ day: 'tuesday' }) // => { day: 'monday' }
 ```

--- a/docs/string/camel.mdx
+++ b/docs/string/camel.mdx
@@ -8,8 +8,8 @@ since: 12.1.0
 
 Given a string returns it in camel case format.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-_.camel('green fish blue fish') // => greenFishBlueFish
+const camelText = _.camel('green fish blue fish') // => greenFishBlueFish
 ```

--- a/docs/string/capitalize.mdx
+++ b/docs/string/capitalize.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a string returns it with the first letter upper cased and all other letters lower cased.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.capitalize('green fish blue FISH') // => Green fish blue fish

--- a/docs/string/dash.mdx
+++ b/docs/string/dash.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a string returns it in dash case format.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.dash('green fish blue fish') // => green-fish-blue-fish

--- a/docs/string/deburr.mdx
+++ b/docs/string/deburr.mdx
@@ -8,7 +8,7 @@ since: 12.8.0
 
 Convert accented Latin letters and ligatures to their plain text equivalents.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.deburr('Crème Brûlée') // => Creme Brulee

--- a/docs/string/dedent.mdx
+++ b/docs/string/dedent.mdx
@@ -8,7 +8,7 @@ since: 12.3.0
 
 Remove indentation from every line of a given string. Optionally, provide your own `indent` to control the amount of indentation to remove. If you don't provide an `indent`, the amount of indentation to remove is determined by the first non-empty line of the given string.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Explicit indentation
@@ -24,7 +24,15 @@ _.dedent('\n    Hello\n    World!\n\n')
 
 When using `dedent` in a tagged template string, the indentation is always inferred.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+
+const userName = 'JohnDoe'
+const orderId = 12345
+const productName = 'Widget'
+const quantity = 2
+// ---cut-before---
+
 // Real-world example: Email template
 const emailTemplate = _.dedent`
   Hello, ${userName}!
@@ -56,7 +64,10 @@ const emailTemplate = _.dedent`
 
 When embedding a string with `dedent`, you don't have to worry about the indentation of the embedded string. For example, if you have an array where each item needs its own line, just join it with `join('\n')` and `dedent` will make sure it all works out.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
+
 const items = ['one', 'two', 'three']
 const list = _.dedent`
   My List:
@@ -71,14 +82,21 @@ There's a common use case of building up a long string of “paragraphs” (for 
 
 Since `dedent` strips the first and last empty line of a given string, your dedented string has no spacing around it by default. You might try to include an empty line at the start of each paragraph to achieve the desired spacing, like the following example.
 
-```ts
-let story = dedent`
+```ts twoslash
+import * as _ from 'radashi'
+
+function isLateAtNight() {
+  return true
+}
+// ---cut-before---
+
+let story = _.dedent`
   There once was a programmer
   who had a lot of trouble.
 `
 
 if (isLateAtNight()) {
-  story += dedent`
+  story += _.dedent`
 
     He was so confused
     that he couldn't even
@@ -101,8 +119,13 @@ Here are 3 possible solutions for this issue. Pick your favorite:
 
 1. Add `\n` to your empty line.
 
-   ```ts
-   story += dedent`
+   ```ts twoslash
+   import * as _ from 'radashi'
+
+   let story = ''
+   // ---cut-before---
+
+   story += _.dedent`
      \n
      He was so confused
      that he couldn't even
@@ -112,9 +135,14 @@ Here are 3 possible solutions for this issue. Pick your favorite:
 
 2. Append the line breaks separately.
 
-   ```ts
+   ```ts twoslash
+   import * as _ from 'radashi'
+
+   let story = ''
+   // ---cut-before---
+
    story += '\n\n'
-   story += dedent`
+   story += _.dedent`
      He was so confused
      that he couldn't even
      tell what was going on.
@@ -123,10 +151,15 @@ Here are 3 possible solutions for this issue. Pick your favorite:
 
 3. Include two empty lines at the start of each paragraph. (An unadvised solution as its intention is not the most clear)
 
-   ```ts
-   story += dedent`
-   
-   
+   ```ts twoslash
+   import * as _ from 'radashi'
+
+   let story = ''
+
+   // ---cut-before---
+   story += _.dedent`
+
+
      He was so confused
      that he couldn't even
      tell what was going on.

--- a/docs/string/escapeHTML.mdx
+++ b/docs/string/escapeHTML.mdx
@@ -14,7 +14,7 @@ Replaces all occurrences of the following characters with their corresponding HT
 - `"` with `&quot;`
 - `'` with `&#39;`
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.escapeHTML('<div>Hello, world!</div>')

--- a/docs/string/pascal.mdx
+++ b/docs/string/pascal.mdx
@@ -8,10 +8,10 @@ since: 12.1.0
 
 Formats the given string in pascal case fashion.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
-_.pascal('hello world') // => 'HelloWorld'
-_.pascal('va va boom') // => 'VaVaBoom'
-_.pascal('helloWorld') // => 'HelloWorld'
+const hw = _.pascal('hello world') // => 'HelloWorld'
+const vvb = _.pascal('va va boom') // => 'VaVaBoom'
+const h2 = _.pascal('helloWorld') // => 'HelloWorld'
 ```

--- a/docs/string/similarity.mdx
+++ b/docs/string/similarity.mdx
@@ -17,7 +17,7 @@ This function is useful for various applications, including:
 
 The function is case-sensitive and treats whitespace as significant characters. The order of the input strings doesn't affect the result, as the Levenshtein distance is symmetric.
 
-```typescript
+```ts
 import * as _ from 'radashi'
 
 // Identical strings

--- a/docs/string/snake.mdx
+++ b/docs/string/snake.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a string returns it in snake case format.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.snake('green fish blue fish') // => green_fish_blue_fish
@@ -16,7 +16,9 @@ _.snake('green fish blue fish') // => green_fish_blue_fish
 
 **Warning**: In v11.0.0 a change was made to _fix_ this function so that it correctly splits numbers from neighboring letters (`hello5` becomes `hello_5`). You can opt out of this behavior and continue with the legacy style (`hello5` becomes `hello5`) by passing the `splitOnNumber` options.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
 _.snake('5green fish 2blue fish') // => 5_green_fish_2_blue_fish
 
 _.snake('5green fish 2blue fish', {

--- a/docs/string/template.mdx
+++ b/docs/string/template.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given a string, an object of data, and a format expression to search for, returns a string with all elements that matched the search replaced with their matching value from the data object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.template('It is {{color}}', { color: 'blue' }) // => It is blue

--- a/docs/string/title.mdx
+++ b/docs/string/title.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Formats the given string in title case fashion
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.title('hello world') // => 'Hello World'

--- a/docs/string/trim.mdx
+++ b/docs/string/trim.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Trims all prefix and suffix characters from the given string. Like the builtin trim function but accepts alternate (other than space) characters you would like to trim.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.trim('  hello ') // => hello
@@ -18,6 +18,8 @@ _.trim('/repos/:owner/', '/') // => repos/:owner
 
 Trim also handles more than one character to trim.
 
-```ts
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
 _.trim('222__hello__111', '12_') // => hello
 ```

--- a/docs/typed/assert.mdx
+++ b/docs/typed/assert.mdx
@@ -10,7 +10,7 @@ The `assert` function from Radashi is used to assert that a given `condition` is
 
 This utility is particularly useful in TypeScript for its ability to perform type narrowing. It uses the `asserts` keyword in its signature. When `assert(condition)` is called and the condition is true, TypeScript understands that the type of any variables involved in the condition can be narrowed down based on that truthiness.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 function processValue(value: string | null | undefined) {
@@ -40,7 +40,7 @@ The `message` can be a string or an instance of the `Error` class.
 - If an `Error` instance is provided, that specific error object will be thrown directly.
 - If no message is provided for a failing assertion, a default message `"Assertion failed"` is used.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Using a custom string message
@@ -63,7 +63,7 @@ A special case exists when the `condition` argument is a literal `false`. In thi
 
 This `never` return type signals to the TypeScript compiler that the code path following this assertion is unreachable. This can be particularly useful in scenarios like exhaustiveness checks within `switch` statements or for indicating impossible states in your type logic.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 type Status = 'success' | 'pending' | 'failed'

--- a/docs/typed/getErrorMessage.mdx
+++ b/docs/typed/getErrorMessage.mdx
@@ -8,7 +8,7 @@ since: 12.8.0
 
 Pass in an unknown error value and get a string that is safe to display or log.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.getErrorMessage(new Error('Request failed')) // => 'Request failed'
@@ -20,7 +20,7 @@ _.getErrorMessage(null) // => 'Unknown error.'
 
 Empty strings and `Error` objects with empty messages return the fallback message.
 
-```ts
+```ts twoslash
 _.getErrorMessage(new Error()) // => 'Unknown error.'
 _.getErrorMessage('') // => 'Unknown error.'
 ```

--- a/docs/typed/isArray.mdx
+++ b/docs/typed/isArray.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is an Array.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isArray('hello') // => false

--- a/docs/typed/isAsyncIterable.mdx
+++ b/docs/typed/isAsyncIterable.mdx
@@ -7,7 +7,7 @@ description: Determine if a value is an async iterable
 
 Returns a boolean if the given value is an object with a `[Symbol.asyncIterator]` method.
 
-```ts
+```ts twoslash
 import { isAsyncIterable } from 'radashi'
 
 isAsyncIterable(

--- a/docs/typed/isBigInt.mdx
+++ b/docs/typed/isBigInt.mdx
@@ -7,7 +7,7 @@ description: 'Determine if a value is a BigInt'
 
 Pass in a value and get a boolean telling you if the value is a bigint, using the `typeof` operator.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isBigInt(0n) // => true

--- a/docs/typed/isBoolean.mdx
+++ b/docs/typed/isBoolean.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Returns true if the value is a `boolean` type. Boxed boolean values (e.g. `new Boolean(false)`) are not considered booleans by this function.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isBoolean(true) // => true

--- a/docs/typed/isClass.mdx
+++ b/docs/typed/isClass.mdx
@@ -8,7 +8,8 @@ since: 12.3.0
 
 This function returns `true` if the provided value is a constructor declared with the ES6 `class` keyword.
 
-```ts
+```ts twoslash
+// @noErrors
 import * as _ from 'radashi'
 
 class MyClass {}

--- a/docs/typed/isDate.mdx
+++ b/docs/typed/isDate.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Determine if a value is a Date. Does not check that the input date is valid, only that it is a Javascript Date type.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isDate(new Date()) // => true

--- a/docs/typed/isEmpty.mdx
+++ b/docs/typed/isEmpty.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is empty.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isEmpty([]) // => true
@@ -36,7 +36,7 @@ In some cases, `isEmpty` acts as a [type guard](https://www.typescriptlang.org/d
 
 Due to TypeScript limitations, object types cannot be narrowed, except for arrays and functions.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 // Example with string

--- a/docs/typed/isEqual.mdx
+++ b/docs/typed/isEqual.mdx
@@ -8,7 +8,8 @@ since: 12.1.0
 
 Given two values, returns true if they are equal.
 
-```ts
+```ts twoslash
+// @errors: 2345
 import * as _ from 'radashi'
 
 _.isEqual(null, null) // => true

--- a/docs/typed/isError.mdx
+++ b/docs/typed/isError.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 This function returns `true` if the input is an instance of the `Error` class or any of its subclasses.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isError(new Error()) // => true

--- a/docs/typed/isFloat.mdx
+++ b/docs/typed/isFloat.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is a float.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isFloat(12.233) // => true

--- a/docs/typed/isFunction.mdx
+++ b/docs/typed/isFunction.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is a function.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isFunction('hello') // => false

--- a/docs/typed/isInt.mdx
+++ b/docs/typed/isInt.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is an int.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isInt(12) // => true

--- a/docs/typed/isIntString.mdx
+++ b/docs/typed/isIntString.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Pass in a value and get a boolean telling you if the value is an int in string form.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isIntString('12') // => true

--- a/docs/typed/isMap.mdx
+++ b/docs/typed/isMap.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 Returns true for `Map` instances, even if they are subclass instances or from
 other [realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isMap(new Map()) // true

--- a/docs/typed/isMapEqual.mdx
+++ b/docs/typed/isMapEqual.mdx
@@ -9,7 +9,7 @@ since: 12.7.0
 Returns true when two `Map` instances contain the same keys and each value is
 deeply equal.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const left = new Map([

--- a/docs/typed/isNullish.mdx
+++ b/docs/typed/isNullish.mdx
@@ -8,7 +8,7 @@ since: 12.3.0
 
 Pass in a value and get a boolean telling you if the value is null or undefined.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isNullish(null) // => true

--- a/docs/typed/isNumber.mdx
+++ b/docs/typed/isNumber.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is a number.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isNumber('hello') // => false

--- a/docs/typed/isObject.mdx
+++ b/docs/typed/isObject.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is an instance of `Object` (or a subclass of `Object`).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isObject('hello') // => false

--- a/docs/typed/isPlainObject.mdx
+++ b/docs/typed/isPlainObject.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Pass in a value and get a boolean telling you if the value is a plain object.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isPlainObject({}) // => true

--- a/docs/typed/isPrimitive.mdx
+++ b/docs/typed/isPrimitive.mdx
@@ -10,7 +10,7 @@ Checks if the given value is primitive.
 
 Primitive Types: number , string , boolean , symbol, bigint, undefined, null
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isPrimitive(22) // => true

--- a/docs/typed/isPromise.mdx
+++ b/docs/typed/isPromise.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 The `isPromise` function checks if a value is "Promise-like" by determining if it has a `then` method.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isPromise({ then: () => {} }) // => true

--- a/docs/typed/isRegExp.mdx
+++ b/docs/typed/isRegExp.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 Returns true for `RegExp` instances, even if they are subclass instances or from
 other [realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isRegExp(/.+/) // true

--- a/docs/typed/isResult.mdx
+++ b/docs/typed/isResult.mdx
@@ -10,7 +10,7 @@ Check if a value is a `Result` tuple.
 
 **Don't know what that is?** Read the [Result](#result) section further down.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isResult([undefined, 42]) // => true
@@ -53,7 +53,9 @@ The names "Ok" and "Err" are inspired by Rust's `std::result` module.
 
 To check for an `Ok` result, do this:
 
-```ts
+```ts twoslash
+import { isResult } from 'radashi'
+// ---cut-before---
 declare const value: unknown
 
 if (isResult(value) && value[0] == null) {
@@ -64,7 +66,10 @@ if (isResult(value) && value[0] == null) {
 
 To check for an `Err` result, do this:
 
-```ts
+```ts twoslash
+import { isResult } from 'radashi'
+// ---cut-before---
+
 declare const value: unknown
 
 if (isResult(value) && value[0] != null) {

--- a/docs/typed/isResultErr.mdx
+++ b/docs/typed/isResultErr.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Check if a value is both a `Result` tuple and an `Err` result.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 declare const value: unknown

--- a/docs/typed/isResultOk.mdx
+++ b/docs/typed/isResultOk.mdx
@@ -8,7 +8,7 @@ since: 12.2.0
 
 Check if a value is both a `Result` tuple and an `Ok` result.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 declare const value: unknown

--- a/docs/typed/isSet.mdx
+++ b/docs/typed/isSet.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 Returns true for `Set` instances, even if they are subclass instances or from
 other [realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isSet(new Set()) // true

--- a/docs/typed/isSetEqual.mdx
+++ b/docs/typed/isSetEqual.mdx
@@ -9,7 +9,7 @@ since: 12.7.0
 Returns true when two `Set` instances contain the same values (compared by
 reference).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 const left = new Set(['a', 'b', 'c'])

--- a/docs/typed/isString.mdx
+++ b/docs/typed/isString.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is a string.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isString('hello') // => true

--- a/docs/typed/isSymbol.mdx
+++ b/docs/typed/isSymbol.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Pass in a value and get a boolean telling you if the value is a Symbol.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isSymbol('hello') // => false

--- a/docs/typed/isUndefined.mdx
+++ b/docs/typed/isUndefined.mdx
@@ -8,7 +8,7 @@ since: 12.3.0
 
 Pass in a value and get a boolean telling you if the value is undefined.
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isUndefined(undefined) // => true

--- a/docs/typed/isWeakMap.mdx
+++ b/docs/typed/isWeakMap.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 Returns true for `WeakMap` instances, even if they are subclass instances or from
 other [realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isWeakMap(new WeakMap()) // true

--- a/docs/typed/isWeakSet.mdx
+++ b/docs/typed/isWeakSet.mdx
@@ -9,7 +9,7 @@ since: 12.2.0
 Returns true for `WeakSet` instances, even if they are subclass instances or from
 other [realms](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
 
-```ts
+```ts twoslash
 import * as _ from 'radashi'
 
 _.isWeakSet(new WeakSet()) // true


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

This PR brings adoption of [twoslash](https://twoslash.netlify.app/) in radashi documentation. This PR should be merged after https://github.com/radashi-org/radashi-org.github.io/pull/6 is closed. No source code besides docs is touched

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

https://github.com/orgs/radashi-org/discussions/298
<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
