### PR TITLE
fix: made select safe with non-array objects/truthy-primitives

### DIFF
--- a/src/array/select.ts
+++ b/src/array/select.ts
@@ -31,7 +31,7 @@ export function select<T, U>(
   mapper: (item: T, index: number) => U,
   condition?: ((item: T, index: number) => boolean) | null,
 ): U[] {
-  if (!array) {
+  if (!Array.isArray(array)) {
     return []
   }
   let mapped: U


### PR DESCRIPTION

## Summary

made select safe with non-array objects/truthy-primitives

## Related issue, if any:

#360 



## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/select.ts` | 161 | +15 (+10%) |

[^1337]: Function size includes the `import` dependencies of the function.



