### PR TITLE
feat: add isAsyncIterable function

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -8,4 +8,6 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Features
 
-####
+#### Add `isAsyncIterable` function
+
+https://github.com/radashi-org/radashi/pull/366

--- a/benchmarks/typed/isAsyncIterable.bench.ts
+++ b/benchmarks/typed/isAsyncIterable.bench.ts
@@ -1,0 +1,17 @@
+import { isAsyncIterable } from 'radashi'
+import { bench, describe } from 'vitest'
+
+describe('isAsyncIterable', () => {
+  const array = [1, 2, 3]
+  const asyncIterable = (async function* () {
+    yield 1
+  })()
+
+  bench('async iterable', () => {
+    isAsyncIterable(asyncIterable)
+  })
+
+  bench('non-async iterable', () => {
+    isAsyncIterable(array)
+  })
+})

--- a/docs/typed/isAsyncIterable.mdx
+++ b/docs/typed/isAsyncIterable.mdx
@@ -1,13 +1,11 @@
 ---
 title: isAsyncIterable
-group: async
+description: Determine if a value is an async iterable
 ---
 
-# isAsyncIterable
+### Usage
 
-Checks if a value is an async iterable.
-
-## Examples
+Returns a boolean if the given value is an object with a `[Symbol.asyncIterator]` method.
 
 ```ts
 import { isAsyncIterable } from 'radashi'
@@ -20,3 +18,5 @@ isAsyncIterable(async function* () {
 isAsyncIterable([1, 2, 3])
 // => false
 ```
+
+If used in an environment where `Symbol.asyncIterator` is not available, the function will use `Symbol.for('Symbol.asyncIterator')` as a fallback.

--- a/docs/typed/isAsyncIterable.mdx
+++ b/docs/typed/isAsyncIterable.mdx
@@ -1,0 +1,22 @@
+---
+title: isAsyncIterable
+group: async
+---
+
+# isAsyncIterable
+
+Checks if a value is an async iterable.
+
+## Examples
+
+```ts
+import { isAsyncIterable } from 'radashi'
+
+isAsyncIterable(async function* () {
+  yield 1
+})
+// => true
+
+isAsyncIterable([1, 2, 3])
+// => false
+```

--- a/docs/typed/isAsyncIterable.mdx
+++ b/docs/typed/isAsyncIterable.mdx
@@ -10,9 +10,11 @@ Returns a boolean if the given value is an object with a `[Symbol.asyncIterator]
 ```ts
 import { isAsyncIterable } from 'radashi'
 
-isAsyncIterable(async function* () {
-  yield 1
-})
+isAsyncIterable(
+  (async function* () {
+    yield 1
+  })(),
+)
 // => true
 
 isAsyncIterable([1, 2, 3])

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -113,6 +113,7 @@ export * from './string/title.ts'
 export * from './string/trim.ts'
 
 export * from './typed/isArray.ts'
+export * from './typed/isAsyncIterable.ts'
 export * from './typed/isBigInt.ts'
 export * from './typed/isBoolean.ts'
 export * from './typed/isClass.ts'

--- a/src/typed/isAsyncIterable.ts
+++ b/src/typed/isAsyncIterable.ts
@@ -1,3 +1,11 @@
+// Whenever Symbol.asyncIterator is missing, use the same symbol that
+// polyfills do (e.g. @azure/core-asynciterator-polyfill).
+const asyncIteratorSymbol: symbol =
+  (Symbol as any).asyncIterator || Symbol.for('Symbol.asyncIterator')
+
+// @ts-ignore: Assume "lib.es2018.asynciterable" is included.
+type AsyncIterable = globalThis.AsyncIterable<unknown>
+
 /**
  * Checks if a value is an async iterable.
  *
@@ -13,12 +21,10 @@
  * @param value The value to check.
  * @returns `true` if the value is an async iterable, `false` otherwise.
  */
-export function isAsyncIterable(value: unknown): // @ts-ignore
-value is globalThis.AsyncIterable<unknown> {
+export function isAsyncIterable(value: unknown): value is AsyncIterable {
   return (
     !!value &&
     typeof value === 'object' &&
-    // @ts-ignore
-    Symbol.asyncIterator in value
+    typeof value[asyncIteratorSymbol as never] === 'function'
   )
 }

--- a/src/typed/isAsyncIterable.ts
+++ b/src/typed/isAsyncIterable.ts
@@ -1,0 +1,24 @@
+/**
+ * Checks if a value is an async iterable.
+ *
+ * @example
+ * ```ts
+ * isAsyncIterable(async function* () { yield 1 })
+ * // => true
+ *
+ * isAsyncIterable([1, 2, 3])
+ * // => false
+ * ```
+ *
+ * @param value The value to check.
+ * @returns `true` if the value is an async iterable, `false` otherwise.
+ */
+export function isAsyncIterable(value: unknown): // @ts-ignore
+value is globalThis.AsyncIterable<unknown> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    // @ts-ignore
+    Symbol.asyncIterator in value
+  )
+}

--- a/src/typed/isAsyncIterable.ts
+++ b/src/typed/isAsyncIterable.ts
@@ -1,7 +1,8 @@
 // Whenever Symbol.asyncIterator is missing, use the same symbol that
 // polyfills do (e.g. @azure/core-asynciterator-polyfill).
 const asyncIteratorSymbol: symbol =
-  (Symbol as any).asyncIterator || Symbol.for('Symbol.asyncIterator')
+  /* c8 ignore next */ (Symbol as any).asyncIterator ||
+  Symbol.for('Symbol.asyncIterator')
 
 // @ts-ignore: Assume "lib.es2018.asynciterable" is included.
 type AsyncIterable = globalThis.AsyncIterable<unknown>

--- a/src/typed/isAsyncIterable.ts
+++ b/src/typed/isAsyncIterable.ts
@@ -11,15 +11,12 @@ type AsyncIterable = globalThis.AsyncIterable<unknown>
  *
  * @example
  * ```ts
- * isAsyncIterable(async function* () { yield 1 })
+ * isAsyncIterable((async function* () { yield 1 })())
  * // => true
  *
  * isAsyncIterable([1, 2, 3])
  * // => false
  * ```
- *
- * @param value The value to check.
- * @returns `true` if the value is an async iterable, `false` otherwise.
  */
 export function isAsyncIterable(value: unknown): value is AsyncIterable {
   return (

--- a/tests/typed/isAsyncIterable.test.ts
+++ b/tests/typed/isAsyncIterable.test.ts
@@ -1,0 +1,29 @@
+import * as _ from 'radashi'
+
+describe('isAsyncIterable', () => {
+  test('returns true for async iterables', () => {
+    expect(
+      _.isAsyncIterable(
+        (async function* () {
+          yield 1
+        })(),
+      ),
+    ).toBe(true)
+
+    expect(
+      _.isAsyncIterable({
+        [Symbol.asyncIterator]: () => ({
+          next: () => ({ done: true, value: undefined }),
+        }),
+      }),
+    ).toBe(true)
+  })
+
+  test('returns false for non-async-iterables', () => {
+    expect(_.isAsyncIterable([1, 2, 3])).toBe(false)
+    expect(_.isAsyncIterable(1)).toBe(false)
+    expect(_.isAsyncIterable({})).toBe(false)
+    expect(_.isAsyncIterable(null)).toBe(false)
+    expect(_.isAsyncIterable(undefined)).toBe(false)
+  })
+})

--- a/tests/typed/isAsyncIterable.test.ts
+++ b/tests/typed/isAsyncIterable.test.ts
@@ -2,6 +2,7 @@ import * as _ from 'radashi'
 
 describe('isAsyncIterable', () => {
   test('returns true for async iterables', () => {
+    // Async iterables created by an async generator function
     expect(
       _.isAsyncIterable(
         (async function* () {
@@ -10,6 +11,7 @@ describe('isAsyncIterable', () => {
       ),
     ).toBe(true)
 
+    // Objects with a `[Symbol.asyncIterator]` method
     expect(
       _.isAsyncIterable({
         [Symbol.asyncIterator]: () => ({


### PR DESCRIPTION
## Summary

This PR adds the `isAsyncIterable` function to the `async` group.
This function checks if a value is an async iterable.

## Related issue, if any:

https://github.com/orgs/radashi-org/discussions/46

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [x] Release notes in [.github/next-minor.md](.github/next-minor.md) or [.github/next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

## Bundle impact

| Status | File | Size [^1337] |
| --- | --- | --- |
| A | `src/typed/isAsyncIterable.ts` | 162 |

[^1337]: Function size includes the `import` dependencies of the function.



