### PR TITLE
fix(types): debounce `flush` method takes no arguments

### DIFF
--- a/src/curry/debounce.ts
+++ b/src/curry/debounce.ts
@@ -11,11 +11,10 @@ export interface DebounceFunction<TArgs extends any[] = any> {
    */
   cancel(): void
   /**
-   * If the debounced function is pending, it will be invoked
-   * immediately and the result will be returned. Otherwise,
-   * `undefined` will be returned.
+   * If a debounced call is scheduled, this invokes it immediately.
+   * Otherwise, this equals Radashi's `noop` function.
    */
-  flush(...args: TArgs): void
+  flush(): void
   /**
    * The underlying function
    */


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
The `flush` method had an outdated signature. This error was introduced in #107.

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
