### PR TITLE
feat: implement toResult function

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -22,4 +22,6 @@ https://github.com/radashi-org/radashi/pull/344
 
 ## New Features
 
-####
+#### Add `toResult` function
+
+https://github.com/radashi-org/radashi/pull/375

--- a/docs/async/toResult.mdx
+++ b/docs/async/toResult.mdx
@@ -1,0 +1,30 @@
+---
+title: toResult
+---
+
+## toResult
+
+Converts a `PromiseLike` to a `Promise<Result>`.
+
+```ts
+import { toResult, Ok, Err } from '@radashi/radashi'
+
+const good = async (): Promise<number> => 1
+const bad = async (): Promise<number> => {
+  throw new Error('bad')
+}
+
+const res = await toResult(good())
+//    ^? Promise<Ok<number> | Err<Error>>
+
+if (res[0] === undefined) {
+  console.log(res[1])
+}
+
+const res2 = await toResult(bad())
+//    ^? Promise<Ok<number> | Err<Error>>
+
+if (res2[0] !== undefined) {
+  console.error(res2[0])
+}
+```

--- a/docs/async/toResult.mdx
+++ b/docs/async/toResult.mdx
@@ -8,7 +8,7 @@ description: Converts a PromiseLike to a Promise<Result>
 Converts a `PromiseLike` to a `Promise<Result>`.
 
 ```ts
-import { toResult, Result } from '@radashi/radashi'
+import { toResult, Result } from 'radashi'
 
 const good = async (): Promise<number> => 1
 const bad = async (): Promise<number> => {
@@ -28,6 +28,16 @@ const res2 = await toResult(bad())
 if (res2[0] !== undefined) {
   console.error(res2[0])
 }
+```
+
+### Throwing non-Error values
+
+If the given promise throws a non-Error value, it will be rethrown. This ensures the `Result` always contains an `Error` value or undefined.
+
+```ts
+// This won't catch the rejected promise, because it was
+// rejected with a string, not an Error.
+const res = await toResult(Promise.reject('test error'))
 ```
 
 ### Synchronous errors

--- a/docs/async/toResult.mdx
+++ b/docs/async/toResult.mdx
@@ -1,13 +1,14 @@
 ---
 title: toResult
+description: Converts a PromiseLike to a Promise<Result>
 ---
 
-## toResult
+### Usage
 
 Converts a `PromiseLike` to a `Promise<Result>`.
 
 ```ts
-import { toResult, Ok, Err } from '@radashi/radashi'
+import { toResult, Result } from '@radashi/radashi'
 
 const good = async (): Promise<number> => 1
 const bad = async (): Promise<number> => {
@@ -15,16 +16,36 @@ const bad = async (): Promise<number> => {
 }
 
 const res = await toResult(good())
-//    ^? Promise<Ok<number> | Err<Error>>
+//    ^? Promise<Result<number>>
 
 if (res[0] === undefined) {
   console.log(res[1])
 }
 
 const res2 = await toResult(bad())
-//    ^? Promise<Ok<number> | Err<Error>>
+//    ^? Promise<Result<number>>
 
 if (res2[0] !== undefined) {
   console.error(res2[0])
 }
+```
+
+### Synchronous errors
+
+This function won't catch synchronous errors. Only rejected promises are converted to an `Err`.
+
+```ts
+function bad() {
+  if (Math.random() > 0.5) {
+    // ⚠️ This error won't be caught by `toResult`. To fix this, add
+    // the `async` keyword to the containing function.
+    throw new Error('bad')
+  }
+  return new Promise((resolve, reject) => {
+    /* ... */
+  })
+}
+
+const res = await toResult(bad())
+//    ^? Promise<Result<number>>
 ```

--- a/docs/async/toResult.mdx
+++ b/docs/async/toResult.mdx
@@ -15,19 +15,11 @@ const bad = async (): Promise<number> => {
   throw new Error('bad')
 }
 
-const res = await toResult(good())
-//    ^? Promise<Result<number>>
+const goodResult = await toResult(good())
+// => [undefined, 1]
 
-if (res[0] === undefined) {
-  console.log(res[1])
-}
-
-const res2 = await toResult(bad())
-//    ^? Promise<Result<number>>
-
-if (res2[0] !== undefined) {
-  console.error(res2[0])
-}
+const badResult = await toResult(bad())
+// => [Error('bad'), undefined]
 ```
 
 ### Throwing non-Error values

--- a/src/async/toResult.ts
+++ b/src/async/toResult.ts
@@ -21,6 +21,7 @@ import type { Result } from '../types'
  * const badResult = await toResult(bad())
  * // => [Error('bad'), undefined]
  * ```
+ * @version 12.4.0
  */
 export async function toResult<T>(promise: PromiseLike<T>): Promise<Result<T>> {
   try {

--- a/src/async/toResult.ts
+++ b/src/async/toResult.ts
@@ -27,10 +27,10 @@ export async function toResult<T>(promise: PromiseLike<T>): Promise<Result<T>> {
   try {
     const result = await promise
     return [undefined, result]
-  } catch (err) {
-    if (isError(err)) {
-      return [err, undefined]
+  } catch (error) {
+    if (isError(error)) {
+      return [error, undefined]
     }
-    throw err
+    throw error
   }
 }

--- a/src/async/toResult.ts
+++ b/src/async/toResult.ts
@@ -1,21 +1,25 @@
+import { isError } from 'radashi'
 import type { Result } from '../types'
 
 /**
- * Converts a PromiseLike to a Promise<Result>.
+ * Converts a `PromiseLike` to a `Promise<Result>`.
  *
+ * Note: If the given promise throws a non-Error value, it will be
+ * rethrown.
+ *
+ * @see https://radashi.js.org/reference/async/toResult
  * @example
  * ```ts
- * import { toResult, Ok } from '@radashi/radashi'
+ * import { toResult, Result } from 'radashi'
  *
  * const good = async (): Promise<number> => 1
  * const bad = async (): Promise<number> => { throw new Error('bad') }
  *
- * const res = await toResult(good())
- * //    ^? Promise<Ok<number> | Err<Error>>
+ * const goodResult = await toResult(good())
+ * // => [undefined, 1]
  *
- * if (res[0] === undefined) {
- *   console.log(res[1])
- * }
+ * const badResult = await toResult(bad())
+ * // => [Error('bad'), undefined]
  * ```
  */
 export async function toResult<T>(promise: PromiseLike<T>): Promise<Result<T>> {
@@ -23,6 +27,9 @@ export async function toResult<T>(promise: PromiseLike<T>): Promise<Result<T>> {
     const result = await promise
     return [undefined, result]
   } catch (err) {
-    return [err instanceof Error ? err : new Error(String(err)), undefined]
+    if (isError(err)) {
+      return [err, undefined]
+    }
+    throw err
   }
 }

--- a/src/async/toResult.ts
+++ b/src/async/toResult.ts
@@ -1,0 +1,28 @@
+import type { Result } from '../types'
+
+/**
+ * Converts a PromiseLike to a Promise<Result>.
+ *
+ * @example
+ * ```ts
+ * import { toResult, Ok } from '@radashi/radashi'
+ *
+ * const good = async (): Promise<number> => 1
+ * const bad = async (): Promise<number> => { throw new Error('bad') }
+ *
+ * const res = await toResult(good())
+ * //    ^? Promise<Ok<number> | Err<Error>>
+ *
+ * if (res[0] === undefined) {
+ *   console.log(res[1])
+ * }
+ * ```
+ */
+export async function toResult<T>(promise: PromiseLike<T>): Promise<Result<T>> {
+  try {
+    const result = await promise
+    return [undefined, result]
+  } catch (err) {
+    return [err instanceof Error ? err : new Error(String(err)), undefined]
+  }
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -42,6 +42,7 @@ export * from './async/retry.ts'
 export * from './async/sleep.ts'
 export * from './async/timeout.ts'
 export * from './async/TimeoutError.ts'
+export * from './async/toResult.ts'
 export * from './async/tryit.ts'
 export * from './async/withResolvers.ts'
 

--- a/tests/async/toResult.test.ts
+++ b/tests/async/toResult.test.ts
@@ -11,7 +11,7 @@ test('converts a rejected promise to Err', async () => {
   const promise = Promise.reject(new Error('test error'))
   const result = await _.toResult(promise)
   expect(result[0]).toBeInstanceOf(Error)
-  expect((result[0] as Error).message).toEqual('test error')
+  expect(result[0]!.message).toEqual('test error')
   expect(result[1]).toBeUndefined()
 })
 
@@ -19,6 +19,22 @@ test('converts a rejected promise with a non-error to Err', async () => {
   const promise = Promise.reject('test error')
   const result = await _.toResult(promise)
   expect(result[0]).toBeInstanceOf(Error)
-  expect((result[0] as Error).message).toEqual('test error')
+  expect(result[0]!.message).toEqual('test error')
   expect(result[1]).toBeUndefined()
+})
+
+test('does not catch synchronous errors', () => {
+  const shouldThrow = true
+  expect(() => {
+    const fn = () => {
+      if (shouldThrow) {
+        // This error is thrown synchronously, not as a rejected promise
+        throw new Error('synchronous error')
+      }
+      return Promise.resolve(1)
+    }
+
+    // The following line will throw immediately, not returning a Result
+    _.toResult(fn())
+  }).toThrow('synchronous error')
 })

--- a/tests/async/toResult.test.ts
+++ b/tests/async/toResult.test.ts
@@ -1,0 +1,24 @@
+import * as _ from 'radashi'
+import { expect, test } from 'vitest'
+
+test('converts a resolved promise to Ok', async () => {
+  const promise = Promise.resolve(1)
+  const result = await _.toResult(promise)
+  expect(result).toEqual([undefined, 1])
+})
+
+test('converts a rejected promise to Err', async () => {
+  const promise = Promise.reject(new Error('test error'))
+  const result = await _.toResult(promise)
+  expect(result[0]).toBeInstanceOf(Error)
+  expect((result[0] as Error).message).toEqual('test error')
+  expect(result[1]).toBeUndefined()
+})
+
+test('converts a rejected promise with a non-error to Err', async () => {
+  const promise = Promise.reject('test error')
+  const result = await _.toResult(promise)
+  expect(result[0]).toBeInstanceOf(Error)
+  expect((result[0] as Error).message).toEqual('test error')
+  expect(result[1]).toBeUndefined()
+})

--- a/tests/async/toResult.test.ts
+++ b/tests/async/toResult.test.ts
@@ -15,12 +15,9 @@ test('converts a rejected promise to Err', async () => {
   expect(result[1]).toBeUndefined()
 })
 
-test('converts a rejected promise with a non-error to Err', async () => {
+test('rethrows non-Error rejections', async () => {
   const promise = Promise.reject('test error')
-  const result = await _.toResult(promise)
-  expect(result[0]).toBeInstanceOf(Error)
-  expect(result[0]!.message).toEqual('test error')
-  expect(result[1]).toBeUndefined()
+  await expect(_.toResult(promise)).rejects.toBe('test error')
 })
 
 test('does not catch synchronous errors', () => {


### PR DESCRIPTION
## Summary

This PR implements the `toResult` function in the async group. It converts a `PromiseLike` to a `Promise<Result>`.

## Related issue, if any:

N/A

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

## Bundle impact

| Status | File | Size [^1337] |
| --- | --- | --- |
| A | `src/async/toResult.ts` | 217 |

[^1337]: Function size includes the `import` dependencies of the function.



