### PR TITLE
chore: improve type safety of the `first` function

### DIFF
--- a/src/array/first.ts
+++ b/src/array/first.ts
@@ -20,6 +20,6 @@ export function first<
   defaultValue?: TDefault,
 ): TArray extends readonly [infer TFirst, ...any[]]
   ? TFirst
-  : TArray[number] | TDefault {
+  : TDefault {
   return array?.length > 0 ? array[0] : defaultValue
 }


### PR DESCRIPTION
The `first` function will return `defaultValue`  When the `array` is empty or invalid.

<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


