### PR TITLE
refactor(range): remove unnecessary break statement in range generator

### DIFF
--- a/src/number/range.ts
+++ b/src/number/range.ts
@@ -29,8 +29,5 @@ export function* range<T = number>(
   const final = end ?? startOrLength
   for (let i = start; i <= final; i += step) {
     yield mapper(i)
-    if (i + step > final) {
-      break
-    }
   }
 }


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

The `i <= final` can achieve normal exit from the loop, and there should be no need to `break` in the loop.

## Summary

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/number/range.ts` | 156 | -14 (-8%) |

[^1337]: Function size includes the `import` dependencies of the function.



