### PR TITLE
fix(mapify): modify the loop to use array indexes

### DIFF
--- a/src/array/mapify.ts
+++ b/src/array/mapify.ts
@@ -25,8 +25,8 @@ export function mapify<T, Key, Value = T>(
     item as unknown as Value,
 ): Map<Key, Value> {
   const map: Map<Key, Value> = new Map()
-  for (const item of array) {
-    map.set(getKey(item, map.size), getValue(item, map.size))
+  for (const [index, item] of array.entries()) {
+    map.set(getKey(item, index), getValue(item, index))
   }
   return map
 }

--- a/tests/array/mapify.test.ts
+++ b/tests/array/mapify.test.ts
@@ -41,4 +41,17 @@ describe('mapify', () => {
     )
     expect(result.get('a0')).toBe('hello0')
   })
+  test('index should be the array index', () => {
+    const list = [
+      { id: 'a', word: 'hello' },
+      { id: 'a', word: 'bye' },
+      { id: 'a', word: 'oh' },
+    ]
+    const result = _.mapify(
+      list,
+      x => x.id,
+      (x, i) => x.word + i,
+    )
+    expect(result.get('a')).toBe('oh2')
+  })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

`index` is the index of the current item in the array in the [doc](https://radashi.js.org/reference/array/mapify/)

But using `map.size` as the index, if the ids are equal, it may not be consistent with expectations.

```ts
  for (const item of array) {
    map.set(getKey(item, map.size), getValue(item, map.size))
  }
```

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/mapify.ts` | 115 | +2 (+2%) |

[^1337]: Function size includes the `import` dependencies of the function.



