### PR TITLE
fix(objectify)!: wrap return type with Partial

### DIFF
--- a/src/array/objectify.ts
+++ b/src/array/objectify.ts
@@ -21,12 +21,9 @@ export function objectify<T, Key extends string | number | symbol, Value = T>(
   array: readonly T[],
   getKey: (item: T) => Key,
   getValue: (item: T) => Value = item => item as unknown as Value,
-): Record<Key, Value> {
-  return array.reduce(
-    (acc, item) => {
-      acc[getKey(item)] = getValue(item)
-      return acc
-    },
-    {} as Record<Key, Value>,
-  )
+): Partial<Record<Key, Value>> {
+  return array.reduce((acc, item) => {
+    acc[getKey(item)] = getValue(item)
+    return acc
+  }, {} as Partial<Record<Key, Value>>)
 }

--- a/tests/array/objectify.test.ts
+++ b/tests/array/objectify.test.ts
@@ -14,8 +14,8 @@ describe('objectify', () => {
       x => x.id,
       x => x,
     )
-    expect(result.a.word).toBe('hello')
-    expect(result.b.word).toBe('bye')
+    expect(result.a?.word).toBe('hello')
+    expect(result.b?.word).toBe('bye')
   })
   test('does not fail on empty input list', () => {
     const result = _.objectify(


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

`objectify` will return `{}` when the array is `[]`. So, `Partial<Record<Key, Value>>` is more suitable

<!-- Describe what the change does and why it should be merged. -->

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

<!-- If yes, describe the impact and migration path for existing applications. -->




