### PR TITLE
feat!: allow lossless `crush` ⇄ `construct` use

### DIFF
--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,4 @@
-import { type Intersect, isArray, isObject, type Simplify } from 'radashi'
+import { type Intersect, isArray, isEmpty, isObject, type Simplify } from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -18,7 +18,7 @@ export function crush<T extends object>(value: T): Crush<T> {
     value: unknown,
     path: string,
   ) {
-    if (isObject(value) || isArray(value)) {
+    if ((isObject(value) || isArray(value)) && !isEmpty(value)) {
       for (const [prop, propValue] of Object.entries(value)) {
         crushReducer(crushed, propValue, path ? `${path}.${prop}` : prop)
       }

--- a/src/object/crush.ts
+++ b/src/object/crush.ts
@@ -1,4 +1,10 @@
-import { type Intersect, isArray, isEmpty, isObject, type Simplify } from 'radashi'
+import {
+  type Intersect,
+  isArray,
+  isEmpty,
+  isObject,
+  type Simplify,
+} from 'radashi'
 
 /**
  * Flattens a deep object to a single dimension, converting the keys
@@ -13,6 +19,9 @@ import { type Intersect, isArray, isEmpty, isObject, type Simplify } from 'radas
  * @version 12.1.0
  */
 export function crush<T extends object>(value: T): Crush<T> {
+  if (isEmpty(value)) {
+    return {} as Crush<T>
+  }
   return (function crushReducer(
     crushed: Crush<T>,
     value: unknown,

--- a/src/object/set.ts
+++ b/src/object/set.ts
@@ -17,9 +17,6 @@ export function set<T extends object, K>(
   path: string,
   value: K,
 ): T {
-  if (value === undefined) {
-    return initial
-  }
   const root: any = clone(initial)
   const keys = path.match(/[^.[\]]+/g)
   keys?.reduce(

--- a/tests/object/construct.test.ts
+++ b/tests/object/construct.test.ts
@@ -21,6 +21,9 @@ describe('construct', () => {
         },
       ],
       timestamp: now,
+      arr: [],
+      empty: {},
+      und: undefined
     }
     expect(
       _.construct({
@@ -33,6 +36,9 @@ describe('construct', () => {
         'enemies.1.name': 'vishnu',
         'enemies.1.power': 58,
         timestamp: now,
+        arr: [],
+        empty: {},
+        und: undefined
       }),
     ).toEqual(ra)
   })

--- a/tests/object/crush.test.ts
+++ b/tests/object/crush.test.ts
@@ -17,6 +17,9 @@ describe('crush', () => {
         },
       ],
       timestamp: now,
+      arr: [],
+      empty: {},
+      und: undefined
     }
     expect(_.crush(ra)).toEqual({
       name: 'ra',
@@ -26,6 +29,9 @@ describe('crush', () => {
       'enemies.0.name': 'hathor',
       'enemies.0.power': 12,
       timestamp: now,
+      arr: [],
+      empty: {},
+      und: undefined
     })
   })
   test('handles arrays', () => {


### PR DESCRIPTION
## Summary

Updates `crush` and `construct` functions to support empty arrays, empty objects, and undefined values

## Related issue, if any:

#386 

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [X] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/object/crush.ts` | 581 | +296 (+104%) |
| M | `src/object/set.ts` | 442 | -23 (-5%) |

[^1337]: Function size includes the `import` dependencies of the function.



