### PR TITLE
feat: add overwrite parameter to assign function

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -10,6 +10,10 @@ https://github.com/radashi-org/radashi/pull/388
 
 ## New Features
 
+#### Add `overwrite` parameter to `assign` function
+
+https://github.com/radashi-org/radashi/pull/394
+
 #### Improve `cluster` type inference
 
 https://github.com/radashi-org/radashi/pull/389

--- a/benchmarks/object/assign.bench.ts
+++ b/benchmarks/object/assign.bench.ts
@@ -26,4 +26,30 @@ describe('assign', () => {
     }
     _.assign(initial, override)
   })
+
+  bench('with in-place modification (overwrite: true)', () => {
+    const initial = {
+      name: 'jay',
+      cards: ['ac'],
+      location: {
+        street: '23 main',
+        state: {
+          abbreviation: 'FL',
+          name: 'Florida',
+        },
+      },
+    }
+    const override = {
+      name: 'charles',
+      cards: ['4c'],
+      location: {
+        street: '8114 capo',
+        state: {
+          abbreviation: 'TX',
+          name: 'Texas',
+        },
+      },
+    }
+    _.assign(initial, override, true)
+  })
 })

--- a/docs/object/assign.mdx
+++ b/docs/object/assign.mdx
@@ -1,12 +1,12 @@
 ---
 title: assign
 description: Merges two objects together recursively
-since: 12.1.0
+since: 12.3.0
 ---
 
 ### Usage
 
-Merges two objects together recursively into a new object applying values from right to left. Recursion only applies to child object properties.
+Merges two objects together recursively applying values from right to left. By default creates a new object, but can modify the first object in-place when `overwrite` is true. Recursion only applies to child object properties.
 
 ```ts
 import * as _ from 'radashi'
@@ -16,6 +16,11 @@ const ra = {
   power: 100,
 }
 
+// Create a new object (default behavior)
 _.assign(ra, { name: 'Loki' })
-// => { name: Loki, power: 100 }
+// => { name: 'Loki', power: 100 }
+
+// Modify ra in-place
+_.assign(ra, { power: 200 }, true)
+// => ra is now { name: 'Ra', power: 200 }
 ```

--- a/docs/object/assign.mdx
+++ b/docs/object/assign.mdx
@@ -1,7 +1,7 @@
 ---
 title: assign
 description: Merges two objects together recursively
-since: 12.3.0
+since: 12.1.0
 ---
 
 ### Usage

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -12,6 +12,9 @@ import {
  * Create a copy of the first object, and then merge the second object
  * into it recursively. Only plain objects are recursively merged.
  *
+ * When overwrite is true, modifies the first object in-place instead
+ * of creating a copy.
+ *
  * @see https://radashi.js.org/reference/object/assign
  * @example
  * ```ts
@@ -20,24 +23,37 @@ import {
  *
  * assign(a, b)
  * // => { a: 1, b: 2, c: 3, p: { a: 4, b: 5 } }
+ *
+ * // Using overwrite:
+ * const x = { a: 0, b: 2, p: { a: 4 } }
+ * const y = { a: 1, c: 3, p: { b: 5 } }
+ *
+ * assign(x, y, true) // x is modified in-place
+ * // x now equals { a: 1, b: 2, c: 3, p: { a: 4, b: 5 } }
  * ```
- * @version 12.1.0
+ * @version 12.3.0
  */
 export function assign<
   TInitial extends Record<keyof any, any>,
   TOverride extends Record<keyof any, any>,
->(initial: TInitial, override: TOverride): Assign<TInitial, TOverride> {
+>(
+  initial: TInitial,
+  override: TOverride,
+  overwrite = false,
+): Assign<TInitial, TOverride> {
   if (!initial || !override) {
     return (initial ?? override ?? {}) as any
   }
   const proto = Object.getPrototypeOf(initial)
-  const merged = proto
-    ? { ...initial }
-    : Object.assign(Object.create(proto), initial)
+  const merged = overwrite
+    ? initial
+    : proto
+      ? { ...initial }
+      : Object.assign(Object.create(proto), initial)
   for (const key of Object.keys(override)) {
     merged[key] =
       isPlainObject(initial[key]) && isPlainObject(override[key])
-        ? assign(initial[key], override[key])
+        ? assign(initial[key], override[key], overwrite)
         : override[key]
   }
   return merged

--- a/src/object/assign.ts
+++ b/src/object/assign.ts
@@ -31,7 +31,7 @@ import {
  * assign(x, y, true) // x is modified in-place
  * // x now equals { a: 1, b: 2, c: 3, p: { a: 4, b: 5 } }
  * ```
- * @version 12.3.0
+ * @version 12.1.0
  */
 export function assign<
   TInitial extends Record<keyof any, any>,

--- a/tests/object/assign.test.ts
+++ b/tests/object/assign.test.ts
@@ -62,4 +62,32 @@ describe('assign', () => {
     expect(result).toEqual({ a: { b: 1, c: 2 } })
     expect(Object.getPrototypeOf(result.a)).toBe(null)
   })
+  test('does not modify original object when overwrite is false', () => {
+    const initial = { a: 1, b: { c: 2 } }
+    const override = { a: 9, b: { d: 4 } }
+
+    const result = _.assign(initial, override)
+
+    expect(result).not.toBe(initial)
+    expect(initial.a).toBe(1)
+    expect(result).toEqual({ a: 9, b: { c: 2, d: 4 } })
+  })
+  test('modifies original object in-place when overwrite is true', () => {
+    const initial = { a: 1, b: { c: 2 } }
+    const override = { a: 9, b: { d: 4 } }
+
+    const result = _.assign(initial, override, true)
+
+    expect(result).toBe(initial)
+    expect(initial).toEqual({ a: 9, b: { c: 2, d: 4 } })
+  })
+  test('modifies nested objects in-place when overwrite is true', () => {
+    const initial = { nested: { prop: 1 } }
+    const nestedRef = initial.nested
+
+    _.assign(initial, { nested: { newProp: 2 } }, true)
+
+    expect(initial.nested).toBe(nestedRef)
+    expect(initial.nested).toEqual({ prop: 1, newProp: 2 })
+  })
 })


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

This PR adds a third parameter "overwrite" to the `assign` function with a default value of `false`. When set to `true`, the function modifies the first object in-place instead of creating a new object. This enhancement provides users with the flexibility to choose between creating a copy (immutable approach) or modifying the original object (mutable approach) based on their specific needs.

## Related issue, if any:

<!-- No related issue -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [x] Release notes in [[next-minor.md](https://claude.ai/chat/.github/next-minor.md)](.github/next-minor.md) or [[next-major.md](https://claude.ai/chat/.github/next-major.md)](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

<!-- If yes, describe the impact and migration path for existing applications. -->

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/object/assign.ts` | 384 | +11 (+3%) |

[^1337]: Function size includes the `import` dependencies of the function.



