### PR TITLE
docs: improve isEqual documentation

### DIFF
--- a/docs/typed/isEqual.mdx
+++ b/docs/typed/isEqual.mdx
@@ -13,6 +13,7 @@ import * as _ from 'radashi'
 
 _.isEqual(null, null) // => true
 _.isEqual([], []) // => true
+_.isEqual({ hello: 'world' }, { hello: 'world' }) // => true
 
 _.isEqual('hello', 'world') // => false
 _.isEqual(22, 'abc') // => false


### PR DESCRIPTION
## Summary

Currently, the isEqual documentation does not include an example demonstrating its use with objects, despite the fact that it supports them. I’ve provided a simple example to illustrate this functionality and to emphasize that object comparisons are indeed supported.

## Related issue, if any:
n/a

## For any code change,
n/a

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?
No

