### PR TITLE
fix(selectFirst): correct return type when condition is undefined (#411)

### DIFF
--- a/src/array/selectFirst.ts
+++ b/src/array/selectFirst.ts
@@ -15,6 +15,20 @@
  * ```
  * @version 12.2.0
  */
+
+// overload when user does not provide a condition -> results filters out nullish
+export function selectFirst<T, U>(
+  array: readonly T[],
+  mapper: (item: T, index: number) => U,
+): NonNullable<U> | undefined
+
+// overload when user does provide a condition -> results may include null
+export function selectFirst<T, U>(
+  array: readonly T[],
+  mapper: (item: T, index: number) => U,
+  condition: (item: T, index: number) => boolean
+): U | undefined
+
 export function selectFirst<T, U>(
   array: readonly T[],
   mapper: (item: T, index: number) => U,

--- a/src/array/selectFirst.ts
+++ b/src/array/selectFirst.ts
@@ -15,18 +15,15 @@
  * ```
  * @version 12.2.0
  */
-
-// overload when user does not provide a condition -> results filters out nullish
 export function selectFirst<T, U>(
   array: readonly T[],
   mapper: (item: T, index: number) => U,
-): NonNullable<U> | undefined
+  condition: (item: T, index: number) => boolean,
+): U | undefined
 
-// overload when user does provide a condition -> results may include null
 export function selectFirst<T, U>(
   array: readonly T[],
-  mapper: (item: T, index: number) => U,
-  condition: (item: T, index: number) => boolean
+  mapper: (item: T, index: number) => U | null | undefined,
 ): U | undefined
 
 export function selectFirst<T, U>(

--- a/tests/array/selectFirst.test-d.ts
+++ b/tests/array/selectFirst.test-d.ts
@@ -1,0 +1,24 @@
+import * as _ from 'radashi'
+
+describe('selectFirst type test', () => {
+  test('selectFirst without condition', () => {
+    const result = _.selectFirst(
+      [1,2,3],
+      item => item > 1? item : null,
+    )
+    // filters out null and returns number | undefined
+    expectTypeOf(result).toEqualTypeOf<number | undefined>()
+  })
+
+  test('selectFirst with condition', () => {
+    const result = _.selectFirst(
+        [1,2,3],
+        x => x > 1 ? x : null,
+        x => x > 1
+    )
+    // Because of condition null is allowed
+    expectTypeOf(result).toEqualTypeOf<number | null | undefined>()
+  })
+
+  test
+})

--- a/tests/array/selectFirst.test-d.ts
+++ b/tests/array/selectFirst.test-d.ts
@@ -1,24 +1,27 @@
 import * as _ from 'radashi'
 
-describe('selectFirst type test', () => {
-  test('selectFirst without condition', () => {
-    const result = _.selectFirst(
-      [1,2,3],
-      item => item > 1? item : null,
-    )
-    // filters out null and returns number | undefined
-    expectTypeOf(result).toEqualTypeOf<number | undefined>()
-  })
-
+describe('selectFirst types', () => {
   test('selectFirst with condition', () => {
+    const array = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+      { id: 3, name: null },
+    ]
     const result = _.selectFirst(
-        [1,2,3],
-        x => x > 1 ? x : null,
-        x => x > 1
+      array,
+      item => item.name,
+      item => item.name !== null,
     )
-    // Because of condition null is allowed
-    expectTypeOf(result).toEqualTypeOf<number | null | undefined>()
+    // No way for TypeScript to infer that the result can't be null
+    expectTypeOf(result).toEqualTypeOf<string | null | undefined>()
   })
-
-  test
+  test('selectFirst without condition', () => {
+    const array = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+      { id: 3, name: null },
+    ]
+    const result = _.selectFirst(array, item => item.name)
+    expectTypeOf(result).toEqualTypeOf<string | undefined>()
+  })
 })


### PR DESCRIPTION
Adds type overloads to ensure selectFirst returns NonNullable<U> | undefined when no condition is provided, aligning behavior with nullish filtering.
 Fixes: `selectFirst` return type doesn't filter out `null` type when `condition` parameter is undefined #411

<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
Adds type overloads to ensure selectFirst returns NonNullable<U> | undefined when no condition is provided, aligning behavior with nullish filtering.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
 Fixes: `selectFirst` return type doesn't filter out `null` type when `condition` parameter is undefined #411

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->






