### PR TITLE
feat: add `parseDuration` and `parseQuantity` functions

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -11,3 +11,11 @@ https://github.com/radashi-org/radashi/pull/407
 #### Semaphore
 
 https://github.com/radashi-org/radashi/pull/415
+
+#### parseDuration
+
+https://github.com/radashi-org/radashi/pull/416
+
+#### parseQuantity
+
+https://github.com/radashi-org/radashi/pull/416

--- a/benchmarks/oop/QuantityParser.bench.ts
+++ b/benchmarks/oop/QuantityParser.bench.ts
@@ -1,0 +1,20 @@
+import * as _ from 'radashi'
+
+describe('QuantityParser', () => {
+  const parser = new _.QuantityParser({
+    units: {
+      penny: 1,
+      nickel: 5,
+    },
+    short: {
+      p: 'penny',
+      n: 'nickel',
+    },
+  })
+
+  bench('parse a custom quantity', () => {
+    parser.parse('1 penny')
+    parser.parse('2 nickels')
+    parser.parse('3n')
+  })
+})

--- a/docs/number/parseDuration.mdx
+++ b/docs/number/parseDuration.mdx
@@ -1,0 +1,62 @@
+---
+title: parseDuration
+description: Parses a duration string into milliseconds
+since: 12.6.0
+---
+
+### Usage
+
+Parse a human-readable duration string (like "1 hour", "2 seconds") into milliseconds.
+
+```ts
+import * as _ from 'radashi'
+
+_.parseDuration('1 second') // => 1_000
+_.parseDuration('1h') // => 3_600_000
+_.parseDuration('1 hour') // => 3_600_000
+_.parseDuration('1.5 hours') // => 5_400_000
+_.parseDuration('-1h') // => -3_600_000
+```
+
+You may use the `DurationParser` class instead, which is more efficient for repeated parsing.
+
+```ts
+import { DurationParser } from 'radashi'
+
+const parser = new DurationParser()
+
+parser.parse('1 hour') // => 3_600_000
+parser.parse('1ms') // => 1
+parser.parse('1.5 hours') // => 5_400_000
+```
+
+The units supported by default are:
+
+- `millisecond` (alias: `ms`)
+- `second` (alias: `s`)
+- `minute` (alias: `m`)
+- `hour` (alias: `h`)
+- `day` (alias: `d`)
+- `week` (alias: `w`)
+
+Years and months are not supported by default, because both vary in length (e.g. leap years, not all months have 30 days). See the next section for how to add custom units.
+
+### Custom units
+
+You may pass additional units to the `parseDuration` function.
+
+```ts
+import * as _ from 'radashi'
+
+const customUnits = {
+  units: {
+    month: 30 * 24 * 60 * 60 * 1000,
+  },
+  short: {
+    mo: 'month',
+  },
+} as const
+
+_.parseDuration('1 month', customUnits)
+// => 2_592_000_000
+```

--- a/docs/number/parseQuantity.mdx
+++ b/docs/number/parseQuantity.mdx
@@ -1,0 +1,110 @@
+---
+name: parseQuantity
+description: Parses a quantity string into its numeric value
+since: 12.6.0
+---
+
+### Usage
+
+Parse a quantity string like `"2 dollars"` into its numeric value. You must provide a
+unit conversion map, with optional short unit aliases.
+
+```ts
+import * as _ from 'radashi'
+
+const moneyUnits = {
+  units: {
+    cent: 1,
+    dollar: 100,
+  },
+  short: {
+    $: 'dollar',
+  },
+} as const
+
+_.parseQuantity('1 cent', moneyUnits)
+// => 1
+
+_.parseQuantity('2 dollars', moneyUnits)
+// => 200
+
+_.parseQuantity('5$', moneyUnits)
+// => 500
+```
+
+You may use the `QuantityParser` class instead, which is more efficient for repeated parsing.
+
+```ts
+const moneyParser = new _.QuantityParser(moneyUnits)
+```
+
+If you specifically need to parse a duration (e.g. "1 hour", "2 seconds") into milliseconds,
+you can use the [`parseDuration`](./parseDuration) function instead.
+
+### Subclassing
+
+You can subclass `QuantityParser` to create a parser for a specific unit.
+
+```ts
+import { QuantityParser, type QuantityString } from 'radashi'
+
+export type DistanceUnit = keyof typeof DistanceParser.units
+export type DistanceShortUnit = keyof typeof DistanceParser.shortUnits
+
+export type DistanceString = QuantityString<DistanceUnit, DistanceShortUnit>
+
+export class DistanceParser extends QuantityParser<DistanceUnit, DistanceShortUnit> {
+  constructor() {
+    super({
+      units: DistanceParser.units,
+      short: DistanceParser.shortUnits,
+    })
+  }
+
+  static units = {
+    kilometer: 1_000,
+    mile: 1_852,
+    yard: 0.9144,
+    foot: 0.3048,
+    meter: 1,
+  } as const
+
+  static shortUnits = {
+    km: 'kilometer',
+    mi: 'mile',
+    yd: 'yard',
+    ft: 'foot',
+    m: 'meter',
+  } as const
+})
+
+// Usage
+const distanceParser = new DistanceParser()
+
+distanceParser.parse('1 kilometer') // => 1_000
+distanceParser.parse('1km') // => 1_000
+distanceParser.parse('1 mile') // => 1_852
+distanceParser.parse('1mi') // => 1_852
+distanceParser.parse('1 yard') // => 0.9144
+distanceParser.parse('1yd') // => 0.9144
+distanceParser.parse('1 foot') // => 0.3048
+distanceParser.parse('1ft') // => 0.3048
+distanceParser.parse('1 meter') // => 1
+```
+
+You may want to create a wrapper function to make it easier to use.
+
+```ts
+import { DistanceParser, type DistanceString } from './DistanceParser'
+
+const parser = new DistanceParser()
+
+export function parseDistance(input: DistanceString): number {
+  return parser.parse(input)
+}
+
+// Usage
+parseDistance('1 kilometer') // => 1_000
+parseDistance('1km') // => 1_000
+parseDistance('1 mile') // => 1_852
+```

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -94,6 +94,8 @@ export * from './object/traverse.ts'
 export * from './object/upperize.ts'
 
 export * from './oop/AggregateError.ts'
+export * from './oop/DurationParser.ts'
+export * from './oop/QuantityParser.ts'
 export * from './oop/Semaphore.ts'
 export * from './oop/TimeoutError.ts'
 

--- a/src/number/parseDuration.ts
+++ b/src/number/parseDuration.ts
@@ -1,0 +1,36 @@
+import { DurationParser, type DurationString } from 'radashi'
+
+/**
+ * Parse a duration string into a number.
+ *
+ * By default, the following units are supported:
+ * - `week`
+ * - `day`
+ * - `hour`
+ * - `minute`
+ * - `second`
+ * - `millisecond`
+ *
+ * By default, months and years are not supported, since these aren't
+ * likely to be useful in the majority of cases and they introduce
+ * ambiguity due to leap years and length differences between months.
+ *
+ * @see https://radashi.js.org/reference/number/parseDuration
+ * @version 12.6.0
+ */
+export function parseDuration(duration: DurationString): number
+
+export function parseDuration<
+  TUnit extends string = never,
+  TShortUnit extends string = never,
+>(
+  duration: NoInfer<DurationString<TUnit, TShortUnit>>,
+  options: DurationParser.Options<TUnit, TShortUnit>,
+): number
+
+export function parseDuration(
+  duration: DurationString<string, string>,
+  options?: DurationParser.Options<string, string>,
+): number {
+  return new DurationParser(options).parse(duration)
+}

--- a/src/number/parseQuantity.ts
+++ b/src/number/parseQuantity.ts
@@ -1,0 +1,22 @@
+import { QuantityParser, type QuantityString } from 'radashi'
+import type { parseDuration } from './parseDuration'
+
+/**
+ * Parse a quantity string into its numeric value. You must provide a
+ * unit conversion map.
+ *
+ * Note that {@link parseDuration `parseDuration`} also exists, which
+ * can be used to parse duration strings (like `1d` or `1 day`).
+ *
+ * @see https://radashi.js.org/reference/number/parseQuantity
+ * @version 12.6.0
+ */
+export function parseQuantity<
+  TUnit extends string,
+  TShortUnit extends string = never,
+>(
+  quantity: QuantityString<TUnit, TShortUnit>,
+  options: QuantityParser.Options<TUnit, TShortUnit>,
+): number {
+  return new QuantityParser(options).parse(quantity)
+}

--- a/src/oop/DurationParser.ts
+++ b/src/oop/DurationParser.ts
@@ -1,0 +1,79 @@
+import type { parseDuration } from '../number/parseDuration'
+import { QuantityParser, type QuantityString } from './QuantityParser'
+
+/**
+ * The default duration units supported by `DurationParser`.
+ */
+export type DurationUnit = keyof typeof DurationParser.units
+
+/**
+ * The default aliases for `DurationUnit`.
+ */
+export type DurationShortUnit = keyof typeof DurationParser.shortUnits
+
+/**
+ * A human-readable duration string.
+ */
+export type DurationString<
+  TUnit extends string = never,
+  TShortUnit extends string = never,
+> = QuantityString<DurationUnit | TUnit, DurationShortUnit | TShortUnit>
+
+/**
+ * Parses a duration string into its numeric value.
+ *
+ * You can use `parseDuration` instead for a light wrapper that
+ * doesn't require the `new` keyword.
+ *
+ * See {@link parseDuration `parseDuration`} for more information.
+ *
+ * @version 12.6.0
+ */
+export class DurationParser<
+  TUnit extends string = never,
+  TShortUnit extends string = never,
+> extends QuantityParser<DurationUnit | TUnit, DurationShortUnit | TShortUnit> {
+  constructor(options?: DurationParser.Options<TUnit, TShortUnit>) {
+    super({
+      units: {
+        ...DurationParser.units,
+        ...options?.units,
+      },
+      short: {
+        ...DurationParser.shortUnits,
+        ...options?.short,
+      },
+    } as QuantityParser.Options<
+      DurationUnit | TUnit,
+      DurationShortUnit | TShortUnit
+    >)
+  }
+
+  static units = {
+    week: 604_800_000,
+    day: 86_400_000,
+    hour: 3_600_000,
+    minute: 60_000,
+    second: 1_000,
+    millisecond: 1,
+  } as const
+
+  static shortUnits = {
+    w: 'week',
+    d: 'day',
+    h: 'hour',
+    m: 'minute',
+    s: 'second',
+    ms: 'millisecond',
+  } as const
+}
+
+export declare namespace DurationParser {
+  /**
+   * The options for a `DurationParser` instance.
+   */
+  export type Options<TUnit extends string, TShortUnit extends string> = {
+    units?: Record<TUnit, number>
+    short?: Record<TShortUnit, TUnit | DurationUnit>
+  }
+}

--- a/src/oop/QuantityParser.ts
+++ b/src/oop/QuantityParser.ts
@@ -1,0 +1,78 @@
+import type { parseQuantity } from '../number/parseQuantity'
+
+/**
+ * A human-readable quantity string.
+ */
+export type QuantityString<
+  Unit extends string,
+  ShortUnit extends string = never,
+> = `1 ${Unit}` | `${number} ${Unit}s` | `${number}${ShortUnit}`
+
+/**
+ * Parses a quantity string into its numeric value.
+ *
+ * You can use `parseQuantity` instead for a light wrapper that
+ * doesn't require the `new` keyword.
+ *
+ * See {@link parseQuantity `parseQuantity`} for more information.
+ *
+ * @version 12.6.0
+ */
+export class QuantityParser<
+  Unit extends string,
+  ShortUnit extends string = never,
+> {
+  private units: Record<Unit, number>
+  private short?: Record<ShortUnit, Unit> | undefined
+
+  constructor({ units, short }: QuantityParser.Options<Unit, ShortUnit>) {
+    this.units = units
+    this.short = short
+  }
+
+  /**
+   * Parse a quantity string into its numeric value
+   *
+   * @throws {Error} If the quantity string is invalid or contains an unknown unit
+   */
+  parse(quantity: QuantityString<Unit, ShortUnit>): number {
+    const match = quantity.match(/^(-?\d+(?:\.\d+)?) ?(\w+)?s?$/)
+    if (!match) {
+      throw new Error(`Invalid quantity, cannot parse: ${quantity}`)
+    }
+
+    let unit = match[2] as Unit | ShortUnit
+    unit = this.short?.[unit as ShortUnit] || (unit as Unit)
+
+    const count = Number.parseFloat(match[1])
+    if (Math.abs(count) > 1 && unit.endsWith('s')) {
+      unit = unit.substring(0, unit.length - 1) as Unit
+    }
+
+    if (!this.units[unit]) {
+      throw new Error(
+        `Invalid unit: ${unit}, makes sure it is one of: ${Object.keys(this.units).join(', ')}`,
+      )
+    }
+
+    return count * this.units[unit]
+  }
+}
+
+export declare namespace QuantityParser {
+  /**
+   * The options for a `QuantityParser` instance.
+   */
+  export type Options<Unit extends string, ShortUnit extends string = never> = {
+    units: Record<Unit, number>
+    short?: Record<ShortUnit, Unit>
+  }
+
+  /**
+   * Convert a `QuantityParser` instance to a human-readable quantity string.
+   */
+  export type ToString<T extends QuantityParser<string, string>> =
+    T extends QuantityParser<infer Unit, infer ShortUnit>
+      ? QuantityString<Unit, ShortUnit>
+      : never
+}

--- a/tests/oop/DurationParser.test.ts
+++ b/tests/oop/DurationParser.test.ts
@@ -1,0 +1,86 @@
+import * as _ from 'radashi'
+
+const ms = 1
+const sec = 1_000
+const minute = 60 * sec
+const hour = 60 * minute
+const day = 24 * hour
+const week = 7 * day
+
+describe('QuantityParser', () => {
+  test('parse a duration string', () => {
+    const parser = new _.DurationParser()
+
+    expect(parser.parse('1 millisecond')).toBe(ms)
+    expect(parser.parse('2 milliseconds')).toBe(2 * ms)
+
+    expect(parser.parse('1 second')).toBe(sec)
+    expect(parser.parse('2 seconds')).toBe(2 * sec)
+
+    expect(parser.parse('1 minute')).toBe(minute)
+    expect(parser.parse('2 minutes')).toBe(2 * minute)
+
+    expect(parser.parse('1 hour')).toBe(hour)
+    expect(parser.parse('2 hours')).toBe(2 * hour)
+
+    expect(parser.parse('1 day')).toBe(day)
+    expect(parser.parse('2 days')).toBe(2 * day)
+
+    expect(parser.parse('1 week')).toBe(week)
+    expect(parser.parse('2 weeks')).toBe(2 * week)
+  })
+
+  test('shorthand units', () => {
+    const parser = new _.DurationParser()
+
+    expect(parser.parse('1ms')).toBe(ms)
+    expect(parser.parse('2ms')).toBe(2 * ms)
+
+    expect(parser.parse('1s')).toBe(sec)
+    expect(parser.parse('2s')).toBe(2 * sec)
+
+    expect(parser.parse('1m')).toBe(minute)
+    expect(parser.parse('2m')).toBe(2 * minute)
+
+    expect(parser.parse('1h')).toBe(hour)
+    expect(parser.parse('2h')).toBe(2 * hour)
+
+    expect(parser.parse('1d')).toBe(day)
+    expect(parser.parse('2d')).toBe(2 * day)
+
+    expect(parser.parse('1w')).toBe(week)
+    expect(parser.parse('2w')).toBe(2 * week)
+  })
+
+  test('custom units', () => {
+    const parser = new _.DurationParser({
+      units: {
+        month: 30 * day,
+      },
+      short: {
+        mo: 'month',
+      },
+    })
+
+    expect(parser.parse('1 month')).toBe(30 * day)
+    expect(parser.parse('2 months')).toBe(60 * day)
+
+    expect(parser.parse('1mo')).toBe(30 * day)
+    expect(parser.parse('2mo')).toBe(60 * day)
+  })
+
+  test('bad input', () => {
+    const parser = new _.DurationParser()
+
+    expect(() =>
+      parser.parse('foo bar' as any),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Error: Invalid quantity, cannot parse: foo bar]',
+    )
+    expect(() =>
+      parser.parse('1 decade' as any),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Error: Invalid unit: decade, makes sure it is one of: week, day, hour, minute, second, millisecond]',
+    )
+  })
+})

--- a/tests/oop/QuantityParser.test.ts
+++ b/tests/oop/QuantityParser.test.ts
@@ -1,0 +1,45 @@
+import * as _ from 'radashi'
+
+describe('QuantityParser', () => {
+  test('parse a custom quantity', () => {
+    const parser = new _.QuantityParser({
+      units: {
+        penny: 1,
+        nickel: 5,
+      },
+      short: {
+        p: 'penny',
+        n: 'nickel',
+      },
+    })
+
+    expect(parser.parse('1 penny')).toBe(1)
+    expect(parser.parse('2 pennys')).toBe(2)
+
+    expect(parser.parse('1 nickel')).toBe(5)
+    expect(parser.parse('2 nickels')).toBe(10)
+
+    expect(parser.parse('1p')).toBe(1)
+    expect(parser.parse('2n')).toBe(10)
+  })
+
+  test('bad input', () => {
+    const parser = new _.QuantityParser({
+      units: {
+        penny: 1,
+      },
+    })
+
+    expect(() =>
+      parser.parse('foo bar' as any),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Error: Invalid quantity, cannot parse: foo bar]',
+    )
+
+    expect(() =>
+      parser.parse('1 yen' as any),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Error: Invalid unit: yen, makes sure it is one of: penny]',
+    )
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->
Follow-up to #332 (thanks to @hugo082 for his preliminary work).

Differences from that PR include:
- Rename `parseHumanDuration` to `parseDuration`
- Changed `parseDuration` to accept only a string argument (no numbers)
  - *This was done to keep the implementation lean.*
- Added the `QuantityParser` and `DurationParser` classes
  - *The base QuantityParser class allows for custom parsers to be implemented easily and efficiently; while the DurationParser class is a subclass used by `parseDuration`.*
- Added `parseQuantity` function

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->
https://github.com/orgs/radashi-org/discussions/150#discussioncomment-10865928

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [x] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] |
| --- | --- | --- |
| A | `src/number/parseDuration.ts` | 820 |
| A | `src/number/parseQuantity.ts` | 525 |
| A | `src/oop/DurationParser.ts` | 780 |
| A | `src/oop/QuantityParser.ts` | 485 |

[^1337]: Function size includes the `import` dependencies of the function.



