### PR TITLE
feat: add arrayEquals function

### DIFF
--- a/benchmarks/array/arrayEquals.bench.ts
+++ b/benchmarks/array/arrayEquals.bench.ts
@@ -1,0 +1,25 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+const arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+const arr2 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+const arr3 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 11]
+const arr4 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+describe('arrayEquals', () => {
+  bench('equal arrays', () => {
+    _.arrayEquals(arr1, arr2)
+  })
+
+  bench('different last element', () => {
+    _.arrayEquals(arr1, arr3)
+  })
+
+  bench('different length', () => {
+    _.arrayEquals(arr1, arr4)
+  })
+
+  bench('empty arrays', () => {
+    _.arrayEquals([], [])
+  })
+})

--- a/docs/array/arrayEquals.mdx
+++ b/docs/array/arrayEquals.mdx
@@ -1,0 +1,31 @@
+---
+title: arrayEquals
+description: Checks if two arrays are equal in length and content
+since: 12.7.0
+---
+
+### Usage
+
+Checks if two arrays are equal in length and content using `Object.is` comparison.
+
+```ts
+import * as _ from 'radashi'
+
+_.arrayEquals([1, 2, 3], [1, 2, 3])
+// => true
+
+_.arrayEquals([1, 2, 3], [1, 2, 4])
+// => false
+
+_.arrayEquals([1, 2], [1, 2, 3])
+// => false
+
+_.arrayEquals([], [])
+// => true
+
+_.arrayEquals([NaN], [NaN])
+// => true (Object.is handles NaN)
+
+_.arrayEquals([0], [-0])
+// => false (Object.is handles +0 and -0)
+```

--- a/src/array/arrayEquals.ts
+++ b/src/array/arrayEquals.ts
@@ -1,0 +1,27 @@
+/**
+ * Checks if two arrays are equal in length and content using
+ * `Object.is` comparison.
+ *
+ * @see https://radashi.js.org/reference/array/arrayEquals
+ * @example
+ * ```ts
+ * _.arrayEquals([1, 2, 3], [1, 2, 3]) // => true
+ * _.arrayEquals([1, 2, 3], [1, 2, 4]) // => false
+ * _.arrayEquals([1, 2], [1, 2, 3]) // => false
+ * _.arrayEquals([], []) // => true
+ * _.arrayEquals([NaN], [NaN]) // => true (Object.is handles NaN)
+ * _.arrayEquals([0], [-0]) // => false (Object.is handles +0 and -0)
+ * ```
+ * @version 12.7.0
+ */
+export function arrayEquals<T>(array1: T[], array2: T[]): boolean {
+  if (array1.length !== array2.length) {
+    return false
+  }
+  for (let i = 0; i < array1.length; i++) {
+    if (!Object.is(array1[i], array2[i])) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,5 @@
 export * from './array/alphabetical.ts'
+export * from './array/arrayEquals.ts'
 export * from './array/boil.ts'
 export * from './array/cartesianProduct.ts'
 export * from './array/castArray.ts'

--- a/tests/array/arrayEquals.test.ts
+++ b/tests/array/arrayEquals.test.ts
@@ -1,0 +1,45 @@
+import * as _ from 'radashi'
+
+describe('arrayEquals', () => {
+  test('returns true for equal arrays', () => {
+    expect(_.arrayEquals([1, 2, 3], [1, 2, 3])).toBe(true)
+  })
+
+  test('returns false for arrays with different lengths', () => {
+    expect(_.arrayEquals([1, 2], [1, 2, 3])).toBe(false)
+    expect(_.arrayEquals([1, 2, 3], [1, 2])).toBe(false)
+  })
+
+  test('returns false for arrays with different content', () => {
+    expect(_.arrayEquals([1, 2, 3], [1, 2, 4])).toBe(false)
+    expect(_.arrayEquals(['a', 'b'], ['a', 'c'])).toBe(false)
+  })
+
+  test('returns true for two empty arrays', () => {
+    expect(_.arrayEquals([], [])).toBe(true)
+  })
+
+  test('handles NaN correctly', () => {
+    expect(_.arrayEquals([Number.NaN], [Number.NaN])).toBe(true)
+    expect(_.arrayEquals([Number.NaN, 1], [Number.NaN, 1])).toBe(true)
+    expect(_.arrayEquals([Number.NaN, 1], [1, Number.NaN])).toBe(false)
+  })
+
+  test('handles +0 and -0 correctly', () => {
+    expect(_.arrayEquals([0], [-0])).toBe(false)
+    expect(_.arrayEquals([-0], [0])).toBe(false)
+    expect(_.arrayEquals([0, 1], [-0, 1])).toBe(false)
+  })
+
+  test('handles object references', () => {
+    const obj1 = { a: 1 }
+    const obj2 = { a: 1 }
+    expect(_.arrayEquals([obj1], [obj1])).toBe(true)
+    expect(_.arrayEquals([obj1], [obj2])).toBe(false) // Different references
+  })
+
+  test('handles mixed types', () => {
+    expect(_.arrayEquals([1, 'a', null], [1, 'a', null])).toBe(true)
+    expect(_.arrayEquals([1, 'a', null], [1, 'a', undefined])).toBe(false)
+  })
+})


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Implement the `arrayEquals` function which checks if two arrays have the same length and items using `Object.is` for comparison.

## Related issue, if any:


## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->