### PR TITLE
feat: use `identity` as default getter for `sort`

### DIFF
--- a/docs/array/sort.mdx
+++ b/docs/array/sort.mdx
@@ -1,12 +1,12 @@
 ---
 title: sort
-description: Sort a list of objects by a numerical property
+description: Sort a list of items by a numerical property or value
 since: 12.1.0
 ---
 
 ### Usage
 
-Given an array of objects, return a new array sorted by the numerical property specified in the get function. A third, and optional, argument allows you to sort in descending order instead of the default ascending order.
+Given an array, return a new array sorted either by the numerical property specified in the get function or the numerical value of its items if no get function is passed. A third, and optional, argument allows you to sort in descending order instead of the default ascending order.
 
 This function only supports numerical sorting. For alphabetic sorting, see the [alphabetical](./alphabetical) function.
 
@@ -30,4 +30,9 @@ const fish = [
 
 _.sort(fish, f => f.weight) // => [bass, trout, marlin]
 _.sort(fish, f => f.weight, true) // => [marlin, trout, bass]
+
+const numbers = [2, 0, 1]
+
+_.sort(numbers) // => [0, 1, 2]
+_.sort(numbers, _.identity, true) // => [2, 1, 0]
 ```

--- a/src/array/sort.ts
+++ b/src/array/sort.ts
@@ -1,3 +1,5 @@
+import { identity } from 'radashi'
+
 /**
  * Sort an array without modifying it and return the newly sorted
  * value.
@@ -18,7 +20,7 @@
  */
 export function sort<T>(
   array: readonly T[],
-  getter: (item: T) => number,
+  getter: (item: T) => number = identity,
   desc = false,
 ): T[] {
   if (!array) {

--- a/tests/array/sort.test.ts
+++ b/tests/array/sort.test.ts
@@ -19,4 +19,11 @@ describe('sort', () => {
     const result = _.sort(null as any as number[], x => x)
     expect(result).toEqual([])
   })
+  test('uses identity when no getter passed', () => {
+    const list = [2, 0, 1]
+    const result = _.sort(list)
+    expect(result[0]).toBe(0)
+    expect(result[1]).toBe(1)
+    expect(result[2]).toBe(2)
+  })
 })


### PR DESCRIPTION
## Summary

This change makes it easier to use `sort` on simple numeric arrays, by using `identity` as a default getter. This is motivated by the fact that vanilla JS doesn't sort numeric arrays like a beginner would probably expect, because it converts the items to strings first:

```js
[0, 2, 10, 1].sort() // => [0, 1, 10, 2] 
```

With this PR you can now do this:

```js
_.sort([0, 2, 10, 1]) // => [0, 1, 2, 10]
```

while previously you **had** to pass a getter like so:

```js
_.sort([0, 2, 10, 1], (number) => number) // => [0, 1, 2, 10]
```

## Related issue, if any:

This PR is based and depends on #422

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Debatable

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/objectify.ts` | 91 | -6 (-6%) |
| M | `src/array/sort.ts` | 156 | +25 (+19%) |

[^1337]: Function size includes the `import` dependencies of the function.



