### PR TITLE
feat: change `sort`'s direction argument to a string

### DIFF
--- a/docs/array/sort.mdx
+++ b/docs/array/sort.mdx
@@ -28,5 +28,5 @@ const fish = [
 ]
 
 _.sort(fish, f => f.weight) // => [bass, trout, marlin]
-_.sort(fish, f => f.weight, true) // => [marlin, trout, bass]
+_.sort(fish, f => f.weight, 'desc') // => [marlin, trout, bass]
 ```

--- a/src/array/sort.ts
+++ b/src/array/sort.ts
@@ -12,18 +12,18 @@
  * ]
  *
  * sort(fish, f => f.weight) // => [Bass, Trout, Marlin]
- * sort(fish, f => f.weight, true) // => [Marlin, Trout, Bass]
+ * sort(fish, f => f.weight, "desc") // => [Marlin, Trout, Bass]
  * ```
  */
 export function sort<T>(
   array: readonly T[],
   getter: (item: T) => number,
-  desc = false,
+  direction: 'asc' | 'desc' = 'asc',
 ): T[] {
   if (!array) {
     return []
   }
   const asc = (a: T, b: T) => getter(a) - getter(b)
   const dsc = (a: T, b: T) => getter(b) - getter(a)
-  return array.slice().sort(desc === true ? dsc : asc)
+  return array.slice().sort(direction === 'desc' ? dsc : asc)
 }

--- a/tests/array/sort.test.ts
+++ b/tests/array/sort.test.ts
@@ -10,7 +10,7 @@ describe('sort', () => {
   })
   test('uses descending order', () => {
     const list = [{ index: 2 }, { index: 0 }, { index: 1 }]
-    const result = _.sort(list, i => i.index, true)
+    const result = _.sort(list, i => i.index, 'desc')
     expect(result[0].index).toBe(2)
     expect(result[1].index).toBe(1)
     expect(result[2].index).toBe(0)


### PR DESCRIPTION
## Summary

This makes it more consistent in regards to `alphabetical`.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes

Every use of `sort(something, something, boolean)` needs to be changed to `sort(something, something, 'desc'|'asc')`
