### PR TITLE
fix(group): use `Object.create(null)` for the returned object

### DIFF
--- a/benchmarks/array/group.bench.ts
+++ b/benchmarks/array/group.bench.ts
@@ -11,4 +11,34 @@ describe('group', () => {
     ]
     _.group(list, x => x.group)
   })
+
+  describe('old version', () => {
+    bench('with groups by provided attribute', () => {
+      const list = [
+        { group: 'a', word: 'hello' },
+        { group: 'b', word: 'bye' },
+        { group: 'a', word: 'oh' },
+        { group: 'b', word: 'hey' },
+        { group: 'c', word: 'ok' },
+      ]
+      group(list, x => x.group)
+    })
+
+    function group<T, Key extends string | number | symbol>(
+      array: readonly T[],
+      getGroupId: (item: T, index: number) => Key,
+    ): { [K in Key]?: T[] } {
+      return array.reduce(
+        (acc, item, index) => {
+          const groupId = getGroupId(item, index)
+          if (!acc[groupId]) {
+            acc[groupId] = []
+          }
+          acc[groupId].push(item)
+          return acc
+        },
+        Object.create(null) as Record<Key, T[]>,
+      )
+    }
+  })
 })

--- a/benchmarks/array/group.bench.ts
+++ b/benchmarks/array/group.bench.ts
@@ -11,34 +11,4 @@ describe('group', () => {
     ]
     _.group(list, x => x.group)
   })
-
-  describe('old version', () => {
-    bench('with groups by provided attribute', () => {
-      const list = [
-        { group: 'a', word: 'hello' },
-        { group: 'b', word: 'bye' },
-        { group: 'a', word: 'oh' },
-        { group: 'b', word: 'hey' },
-        { group: 'c', word: 'ok' },
-      ]
-      group(list, x => x.group)
-    })
-
-    function group<T, Key extends string | number | symbol>(
-      array: readonly T[],
-      getGroupId: (item: T, index: number) => Key,
-    ): { [K in Key]?: T[] } {
-      return array.reduce(
-        (acc, item, index) => {
-          const groupId = getGroupId(item, index)
-          if (!acc[groupId]) {
-            acc[groupId] = []
-          }
-          acc[groupId].push(item)
-          return acc
-        },
-        Object.create(null) as Record<Key, T[]>,
-      )
-    }
-  })
 })

--- a/docs/array/group.mdx
+++ b/docs/array/group.mdx
@@ -1,12 +1,12 @@
 ---
 title: group
-description: 'Sort an array of items into groups'
+description: Categorize elements from an array into distinct groups
 since: 12.1.0
 ---
 
 ### Usage
 
-Given an array of items, `group` will build up an object where each key is an array of the items that belong in that group. Generally, this can be useful to categorize an array.
+Given an array of items, `group` will build up an object where each key is an array of the items that belong in that group.
 
 ```ts
 import * as _ from 'radashi'

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -19,7 +19,7 @@ export function group<T, Key extends string | number | symbol>(
   const groups = {} as Record<Key, T[]>
   array.forEach((item, index) => {
     const groupId = getGroupId(item, index)
-    if (!Array.isArray(groups[groupId])) {
+    if (!Object.prototype.hasOwnProperty.call(groups, groupId)) {
       groups[groupId] = []
     }
     groups[groupId].push(item)

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -16,15 +16,13 @@ export function group<T, Key extends string | number | symbol>(
   array: readonly T[],
   getGroupId: (item: T, index: number) => Key,
 ): { [K in Key]?: T[] } {
-  return array.reduce(
-    (acc, item, index) => {
-      const groupId = getGroupId(item, index)
-      if (!acc[groupId]) {
-        acc[groupId] = []
-      }
-      acc[groupId].push(item)
-      return acc
-    },
-    Object.create(null) as Record<Key, T[]>,
-  )
+  const groups = Object.create(null) as Record<Key, T[]>
+  array.forEach((item, index) => {
+    const groupId = getGroupId(item, index)
+    if (!groups[groupId]) {
+      groups[groupId] = []
+    }
+    groups[groupId].push(item)
+  })
+  return groups
 }

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -1,13 +1,14 @@
 /**
- * Sorts an `array` of items into groups. The return value is a map
- * where the keys are the group IDs the given `getGroupId` function
- * produced and the value is an array of each item in that group.
+ * Categorizes elements from an `array` into distinct groups. The
+ * function returns an object where each key is a category identifier
+ * determined by the `getGroupId` function, and each value is an array
+ * containing all elements that belong to that category.
  *
  * @see https://radashi.js.org/reference/array/group
  * @example
  * ```ts
  * group([1, 2, 3, 4], (n) => n % 2 === 0 ? 'even' : 'odd')
- * // { even: [2], odd: [1, 3, 4] }
+ * // { even: [2, 4], odd: [1, 3] }
  * ```
  * @version 12.1.0
  */

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -16,10 +16,10 @@ export function group<T, Key extends string | number | symbol>(
   array: readonly T[],
   getGroupId: (item: T, index: number) => Key,
 ): { [K in Key]?: T[] } {
-  const groups = {} as Record<Key, T[]>
+  const groups = Object.create(null) as Record<Key, T[]>
   array.forEach((item, index) => {
     const groupId = getGroupId(item, index)
-    if (!Object.prototype.hasOwnProperty.call(groups, groupId)) {
+    if (!groups[groupId]) {
       groups[groupId] = []
     }
     groups[groupId].push(item)

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -24,6 +24,6 @@ export function group<T, Key extends string | number | symbol>(
       acc[groupId].push(item)
       return acc
     },
-    {} as Record<Key, T[]>,
+    Object.create(null) as Record<Key, T[]>,
   )
 }

--- a/src/array/group.ts
+++ b/src/array/group.ts
@@ -16,10 +16,10 @@ export function group<T, Key extends string | number | symbol>(
   array: readonly T[],
   getGroupId: (item: T, index: number) => Key,
 ): { [K in Key]?: T[] } {
-  const groups = Object.create(null) as Record<Key, T[]>
+  const groups = {} as Record<Key, T[]>
   array.forEach((item, index) => {
     const groupId = getGroupId(item, index)
-    if (!groups[groupId]) {
+    if (!Array.isArray(groups[groupId])) {
       groups[groupId] = []
     }
     groups[groupId].push(item)

--- a/tests/array/group.test.ts
+++ b/tests/array/group.test.ts
@@ -48,4 +48,12 @@ describe('group', () => {
     expect(groups.even).toEqual([1, 3, 5])
     expect(groups.odd).toEqual([2, 4])
   })
+  test('allows use of keys present on Object.prototype', () => {
+    const list = Object.getOwnPropertyNames(Object.prototype)
+    const groups = _.group(list, key => key)
+    expect(groups.constructor).toEqual(['constructor'])
+    expect(groups.hasOwnProperty).toEqual(['hasOwnProperty'])
+    expect(groups.__proto__).toEqual(['__proto__'])
+    expect(groups.toString).toEqual(['toString'])
+  })
 })


### PR DESCRIPTION
## Summary

This ensures any string can be returned by the `getGroupId` callback.

Solutions I considered:
1. Using `!Array.isArray(…)` for array initialization
2. Using `!Object.prototype.hasOwnProperty.call(…)` for array initialization
3. Using `Object.create(null)` as the container

- Solution 3 appears to have a performance cliff on older hardware (~30% slower).
- Solutions 1 and 2 are even worse in that regard (~70% slower).

Going with solution 3.

## Related issue, if any:

Fixes https://github.com/sodiray/radash/issues/460

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/group.ts` | 133 | +15 (+13%) |

[^1337]: Function size includes the `import` dependencies of the function.



