### PR TITLE
fix(string/dash): add number boundaries to dash function

### DIFF
--- a/src/string/dash.ts
+++ b/src/string/dash.ts
@@ -1,4 +1,4 @@
-import { capitalize } from 'radashi'
+import {capitalize} from 'radashi'
 
 /**
  * Formats the given string in dash case fashion.
@@ -9,6 +9,9 @@ import { capitalize } from 'radashi'
  * dash('hello world') // => 'hello-world'
  * dash('one two_THREE') // => 'one-two-three'
  * dash('helloWord') // => 'hello-word'
+ * dash('123hello') // => '123-hello'
+ * dash('hello123world') // => 'hello-123-world'
+ * dash('hello123') // => 'hello-123'
  * ```
  * @version 12.1.0
  */
@@ -16,7 +19,8 @@ export function dash(str: string): string {
   const parts =
     str
       ?.replace(/([A-Z])+/g, capitalize)
-      ?.split(/(?=[A-Z])|[\.\-\s_]/)
+      ?.split(/(?=[A-Z])|(\d+)|[\.\-\s_]/)
+      .filter(Boolean)
       .map(x => x.toLowerCase()) ?? []
   if (parts.length === 0) {
     return ''

--- a/tests/string/dash.test.ts
+++ b/tests/string/dash.test.ts
@@ -21,6 +21,18 @@ describe('dash', () => {
     const result = _.dash('hello-world')
     expect(result).toBe('hello-world')
   })
+  test('must handle strings starting with numbers', () => {
+    const result = _.dash('123hello')
+    expect(result).toBe('123-hello')
+  })
+  test('must handle numbers between letters', () => {
+  const result = _.dash('hello123world')
+  expect(result).toBe('hello-123-world')
+  })
+  test('must handle strings ending with numbers', () => {
+    const result = _.dash('hello123')
+    expect(result).toBe('hello-123')
+  })
   test('returns non alphanumerics with -', () => {
     const result = _.dash('Exobase Starter_flash AND-go')
     expect(result).toBe('exobase-starter-flash-and-go')


### PR DESCRIPTION
## Fix dash function to align with lodash kebabCase for number boundaries

Fixes #408

### What
Enhanced `dash` function to treat numbers as separate tokens, enabling existing hyphenation at alphanumeric boundaries.

### Why  
Align with lodash `kebabCase` behavior where numbers are treated as distinct words.

### Before / After
```ts
// Before
dash('hello123') // => 'hello123'
dash('hello123world') // => 'hello123world'

// After  
dash('hello123') // => 'hello-123'
dash('hello123world') // => 'hello-123-world'
```

### Implementation
Split digits into separate tokens by adding `(\d+)` to the regex:

```ts
// Before
?.split(/(?=[A-Z])|[\.\-\s_]/)

// After
?.split(/(?=[A-Z])|(\d+)|[\.\-\s_]/)
```

### Breaking Changes
None - existing functionality preserved.