### PR TITLE
fix: range creates array with only one element when end is 0

### DIFF
--- a/src/number/range.ts
+++ b/src/number/range.ts
@@ -25,7 +25,7 @@ export function* range<T = number>(
   step = 1,
 ): Generator<T> {
   const mapper = isFunction(valueOrMapper) ? valueOrMapper : () => valueOrMapper
-  const start = end ? startOrLength : 0
+  const start = end !== undefined ? startOrLength : 0
   const final = end ?? startOrLength
   for (let i = start; i <= final; i += step) {
     yield mapper(i)

--- a/tests/number/range.test.ts
+++ b/tests/number/range.test.ts
@@ -14,6 +14,7 @@ describe('range', () => {
     expect(toList(_.range(0, 4))).toEqual([0, 1, 2, 3, 4])
     expect(toList(_.range(3))).toEqual([0, 1, 2, 3])
     expect(toList(_.range(0, 3))).toEqual([0, 1, 2, 3])
+    expect(toList(_.range(-3, 0))).toEqual([-3, -2, -1, 0])
     expect(toList(_.range(0, 3, 'y'))).toEqual(['y', 'y', 'y', 'y'])
     expect(toList(_.range(0, 3, () => 'y'))).toEqual(['y', 'y', 'y', 'y'])
     expect(toList(_.range(0, 3, i => i))).toEqual([0, 1, 2, 3])


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

- Fix bug where `range` creates an array with only one element when `end` is `0`
  - e.g. `range(-3, 0)` returned `[0]` instead of `[-3, -2, -1, 0]`
- Problem: Because `0` is falsy the `start` was overwritten with `0` when `end` is `0` resulting in the array `[0]`
- Solution: Explicitly check for `end !== undefined` to prevent this
- Add test case where `end` is `0`

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/number/range.ts` | 165 | +9 (+6%) |

[^1337]: Function size includes the `import` dependencies of the function.



