### PR TITLE
feat(docs): document & test that unique() preserves the original order

### DIFF
--- a/docs/array/unique.mdx
+++ b/docs/array/unique.mdx
@@ -8,7 +8,7 @@ since: 12.1.0
 
 Given an array of items -- and optionally, a function to determine their identity -- return a new array without any duplicates.
 
-The function does not preserve the original order of items.
+The function preserves the original order of items, keeping the first occurence and omitting duplicates.
 
 ```ts
 import * as _ from 'radashi'
@@ -26,8 +26,8 @@ const fish = [
   },
   {
     name: 'Salmon',
-    weight: 22,
-    source: 'river',
+    weight: 23,
+    source: 'stream',
   },
 ]
 

--- a/tests/array/unique.test.ts
+++ b/tests/array/unique.test.ts
@@ -9,9 +9,9 @@ describe('unique', () => {
   test('uses key fn to correctly remove duplicate items', () => {
     const list = [
       { id: 'a', word: 'hello' },
-      { id: 'a', word: 'hello' },
+      { id: 'a', word: 'goodbye' },
       { id: 'b', word: 'oh' },
-      { id: 'b', word: 'oh' },
+      { id: 'b', word: 'no' },
       { id: 'c', word: 'yolo' },
     ]
     const result = _.unique(list, x => x.id)


### PR DESCRIPTION


<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Hi,

The [documentation for `unique()`](https://radashi.js.org/reference/array/unique/) currently says "does not preserve the original order of items".  I was all set to start a discussion proposing changing the function to preserve the order since:
* Preserving the order is generally more useful than jumbling it
* It would be backwards-compatible, since until now nobody could rightly depend on the order anyway
* Preserving the order is reasonably common behavior in other libraries (e.g. [lodash](https://lodash.com/docs/4.17.15#uniq])) and languages (e.g. [ruby](https://apidock.com/ruby/Array/uniq)) that I'm familiar with
* I assumed it could be implemented just as efficiently.    

To verify that last assumption, I took a look at the [current source code](https://github.com/radashi-org/radashi/blob/main/src/array/unique.ts) -- and saw that it *already* preserves the order!  

(For the case of no `key`,  the `Set` iterator is defined to traverse in insertion order, and for the case of `key`, `array.reduce()` also traverses in array order.)

So this PR just changes the doc to describe the current behavior.  And includes a change to the example in the doc to make the behavior more clear, and changes one test to verify the behavior more explicitly.

## Related issue, if any:

None that I found.

## For any code change,

No code change!
<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->


No

<!-- If yes, describe the impact and migration path for existing applications. -->
