### PR TITLE
feat: preserve tuple type in `min`/`max` even with a `getter`

### DIFF
--- a/src/number/max.ts
+++ b/src/number/max.ts
@@ -12,6 +12,10 @@
 export function max(array: readonly [number, ...number[]]): number
 export function max(array: readonly number[]): number | null
 export function max<T>(
+  array: readonly [T, ...T[]],
+  getter: (item: T) => number,
+): T
+export function max<T>(
   array: readonly T[],
   getter: (item: T) => number,
 ): T | null

--- a/src/number/min.ts
+++ b/src/number/min.ts
@@ -12,6 +12,10 @@
 export function min(array: readonly [number, ...number[]]): number
 export function min(array: readonly number[]): number | null
 export function min<T>(
+  array: readonly [T, ...T[]],
+  getter: (item: T) => number,
+): T
+export function min<T>(
   array: readonly T[],
   getter: (item: T) => number,
 ): T | null


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Very similar to #421, this improves the return types of `min` and `max` to preserve input tuples.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->
