### PR TITLE
feat(objectify): add `index` parameter to getKey and getValue functions

### DIFF
--- a/docs/array/objectify.mdx
+++ b/docs/array/objectify.mdx
@@ -7,8 +7,23 @@ since: 12.1.0
 ### Usage
 
 Given an array of items, create a dictionary with keys and values mapped by given functions.
-First argument is the array to map. The second argument is the function to determine the key
-for each item. The third argument is optional and determines the value for each item.
+
+#### Parameters
+
+1. `array`: The input array to be converted into an object.
+2. `getKey`: A function that determines the key for each item in the array. It receives two arguments:
+   - `item`: The current array item.
+   - `index`: The index of the current item in the array.
+3. `getValue` (optional): A function that determines the value for each item in the array. If not provided, the original array item is used as the value. It also receives two arguments:
+   - `item`: The current array item.
+   - `index`: The index of the current item in the array.
+
+#### Return Value
+
+Returns a new dictionary object where keys and values are derived from the input array using the provided mapping functions.
+
+#### Example
+
 
 ```ts
 import * as _ from 'radashi'

--- a/src/array/objectify.ts
+++ b/src/array/objectify.ts
@@ -19,12 +19,12 @@
  */
 export function objectify<T, Key extends string | number | symbol, Value = T>(
   array: readonly T[],
-  getKey: (item: T) => Key,
-  getValue: (item: T) => Value = item => item as unknown as Value,
+  getKey: (item: T, index: number) => Key,
+  getValue: (item: T, index: number) => Value = item => item as unknown as Value,
 ): Record<Key, Value> {
   return array.reduce(
-    (acc, item) => {
-      acc[getKey(item)] = getValue(item)
+    (acc, item, i) => {
+      acc[getKey(item, i)] = getValue(item, i)
       return acc
     },
     {} as Record<Key, Value>,

--- a/tests/array/objectify.test.ts
+++ b/tests/array/objectify.test.ts
@@ -11,11 +11,11 @@ describe('objectify', () => {
   test('returns correct map of values', () => {
     const result = _.objectify(
       list,
-      x => x.id,
-      x => x,
+      (x, i) => `${x.id}_${i}`,
+      (x, i) => `${x.word}-${i}`,
     )
-    expect(result.a.word).toBe('hello')
-    expect(result.b.word).toBe('bye')
+    expect(result.a_0).toBe('hello-0')
+    expect(result.b_1).toBe('bye-1')
   })
   test('does not fail on empty input list', () => {
     const result = _.objectify(


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Added `index` parameter to the getKey and getValue functions of objectify, passing the index of the item in the array.

```
obj = objectify(array, (item, index) => ..., (item, index) => ...)
```

This is handy for many use cases, and is consistent with `mapify()` which already has those parameters.

Updated the doc by grabbing the Parameters block verbatim from mapify.mdx, and also added Return Value and Example sections as per maptify's doc.

## Related issue, if any:

n/a

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [x ] Related documentation has been updated, if needed
- [ x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->


No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/objectify.ts` | 97 | +6 (+7%) |

[^1337]: Function size includes the `import` dependencies of the function.



