### PR TITLE
fix: ensure DurationParser static properties can be tree-shaked

### DIFF
--- a/src/oop/DurationParser.ts
+++ b/src/oop/DurationParser.ts
@@ -19,6 +19,24 @@ export type DurationString<
   TShortUnit extends string = never,
 > = QuantityString<DurationUnit | TUnit, DurationShortUnit | TShortUnit>
 
+const DURATION_UNITS = {
+  week: 604_800_000,
+  day: 86_400_000,
+  hour: 3_600_000,
+  minute: 60_000,
+  second: 1_000,
+  millisecond: 1,
+} as const
+
+const DURATION_SHORT_UNITS = {
+  w: 'week',
+  d: 'day',
+  h: 'hour',
+  m: 'minute',
+  s: 'second',
+  ms: 'millisecond',
+} as const
+
 /**
  * Parses a duration string into its numeric value.
  *
@@ -49,23 +67,13 @@ export class DurationParser<
     >)
   }
 
-  static units = {
-    week: 604_800_000,
-    day: 86_400_000,
-    hour: 3_600_000,
-    minute: 60_000,
-    second: 1_000,
-    millisecond: 1,
-  } as const
+  static get units(): typeof DURATION_UNITS {
+    return DURATION_UNITS
+  }
 
-  static shortUnits = {
-    w: 'week',
-    d: 'day',
-    h: 'hour',
-    m: 'minute',
-    s: 'second',
-    ms: 'millisecond',
-  } as const
+  static get shortUnits(): typeof DURATION_SHORT_UNITS {
+    return DURATION_SHORT_UNITS
+  }
 }
 
 export declare namespace DurationParser {


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

<!-- Describe what the change does and why it should be merged. -->

Currently, `DurationParser` defines its static properties (units and shortUnits) directly on the class body:

https://github.com/radashi-org/radashi/blob/900f2e8f892e2af7a91033db524b46b4a096833d/src/oop/DurationParser.ts#L52-L68

When compiled to JavaScript, these static fields become runtime assignments:

```ts
_DurationParser.units = {
  week: 6048e5,
  day: 864e5,
  hour: 36e5,
  minute: 6e4,
  second: 1e3,
  millisecond: 1
};
_DurationParser.shortUnits = {
  w: "week",
  d: "day",
  h: "hour",
  m: "minute",
  s: "second",
  ms: "millisecond"
};
```

This introduces side effects, so bundler cannot safely tree-shake the class — even if DurationParser or its static members are never imported or used.

As a result, these static objects are always included in the final bundle, increasing output size unnecessarily.

## Related issue, if any:

<!-- Paste issue's link or number hashtag here. -->

## For any code change,

<!-- (Change "[ ]" to "[x]" to check a box.) -->

- [ ] Related documentation has been updated, if needed
- [ ] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

No

<!-- If yes, describe the impact and migration path for existing applications. -->


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/oop/DurationParser.ts` | 804 | +24 (+3%) |

[^1337]: Function size includes the `import` dependencies of the function.



