### PR TITLE
feat!: transpile to Node18 syntax

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: { radashi: 'src/mod.ts' },
   format: ['cjs', 'esm'],
   dts: true,
-  target: 'node16',
+  target: 'node18',
   pure: ['Symbol'],
   treeshake: {
     preset: 'smallest',


### PR DESCRIPTION
<!--
  Please write in English.
  Please follow the template, all sections are required.
  Consider opening a feature request first to get your change idea approved.
-->

## Summary

Change the compile target from `node16` to `node18`. This prevents the bundler from rewriting `static` class members into non-treeshakable syntax (see #447).

This is a breaking change, as it may require downstream code to update their compilation target, since the following syntax is now preserved in the Radashi dist bundle:
- `?.` operator
- `static {}` blocks in `class` declarations

## Related issue, if any:

#447

## Does this PR introduce a breaking change?

<!-- (Pick one by deleting the other) -->

Yes
