### PR TITLE
feat: add unawaited function

### DIFF
--- a/.github/next-minor.md
+++ b/.github/next-minor.md
@@ -4,7 +4,9 @@ The `####` headline should be short and descriptive of the new functionality. In
 
 ## New Functions
 
-####
+#### `unawaited`
+
+https://github.com/radashi-org/radashi/pull/464
 
 ## New Features
 

--- a/benchmarks/async/unawaited.bench.ts
+++ b/benchmarks/async/unawaited.bench.ts
@@ -1,0 +1,9 @@
+import * as _ from 'radashi'
+import { bench } from 'vitest'
+
+describe('unawaited', () => {
+  const promise = Promise.resolve()
+  bench('unawaited', () => {
+    _.unawaited(promise)
+  })
+})

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -48,6 +48,7 @@ words:
   - smidge
   - supabase
   - tryit
+  - unawaited
   - upperize
   - upserting
   - urlencode

--- a/docs/async/unawaited.mdx
+++ b/docs/async/unawaited.mdx
@@ -1,0 +1,18 @@
+---
+title: unawaited
+description: Attaches console.error to a given promise
+---
+
+### Usage
+
+Pass a promise to `unawaited` to ensure that any rejection is logged to the console instead of resulting in an unhandled promise rejection.
+
+```ts
+import * as _ from 'radashi'
+
+async function someAsyncFunction() {
+  throw new Error('Something went wrong')
+}
+
+_.unawaited(someAsyncFunction())
+```

--- a/src/async/unawaited.ts
+++ b/src/async/unawaited.ts
@@ -1,0 +1,17 @@
+declare const console: {
+  error: (...args: any[]) => void
+}
+
+/**
+ * Attaches a rejection handler that logs to console.error.
+ *
+ * @see https://radashi.js.org/reference/async/unawaited
+ * @example
+ * ```ts
+ * unawaited(asyncFunction())
+ * ```
+ * @version 12.3.0
+ */
+export function unawaited(promise: Promise<unknown>): void {
+  promise.catch(console.error)
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -46,6 +46,7 @@ export * from './async/sleep.ts'
 export * from './async/timeout.ts'
 export * from './async/toResult.ts'
 export * from './async/tryit.ts'
+export * from './async/unawaited.ts'
 export * from './async/withResolvers.ts'
 
 export * from './curry/callable.ts'

--- a/tests/async/unawaited.test.ts
+++ b/tests/async/unawaited.test.ts
@@ -1,0 +1,18 @@
+import * as _ from 'radashi'
+
+describe('unawaited', () => {
+  test('returns undefined', () => {
+    expect(_.unawaited(Promise.resolve())).toBe(undefined)
+  })
+
+  test('calls console.error when promise rejects', async () => {
+    const error = new Error('test')
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const promise = Promise.reject(error)
+    _.unawaited(promise)
+    // We need to wait for the next tick to ensure the catch handler has been called
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(spy).toHaveBeenCalledWith(error)
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds a new function `unawaited` to the `async` group. This function attaches a rejection handler to a given promise that logs any errors to `console.error`. This is useful for fire-and-forget promises where you want to ensure rejections are at least logged and don't result in unhandled promise rejections.

## Related issue, if any:

None.

## For any code change,

- [x] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [x] Related benchmarks have been added or updated, if needed
- [x] Release notes in [next-minor.md](.github/next-minor.md) or [next-major.md](.github/next-major.md) have been added, if needed

## Does this PR introduce a breaking change?

No

## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| A | `src/async/unawaited.ts` | 61 | +61 |

[^1337]: Function size includes the `import` dependencies of the function.



