### PR TITLE
feat: add `getErrorMessage` function

### DIFF
--- a/docs/typed/getErrorMessage.mdx
+++ b/docs/typed/getErrorMessage.mdx
@@ -1,0 +1,26 @@
+---
+title: getErrorMessage
+description: 'Get a readable message from an unknown error value'
+since: 12.8.0
+---
+
+### Usage
+
+Pass in an unknown error value and get a string that is safe to display or log.
+
+```ts
+import * as _ from 'radashi'
+
+_.getErrorMessage(new Error('Request failed')) // => 'Request failed'
+_.getErrorMessage('Request failed') // => 'Request failed'
+_.getErrorMessage(null) // => 'Unknown error.'
+```
+
+### Empty messages
+
+Empty strings and `Error` objects with empty messages return the fallback message.
+
+```ts
+_.getErrorMessage(new Error()) // => 'Unknown error.'
+_.getErrorMessage('') // => 'Unknown error.'
+```

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -134,6 +134,7 @@ export * from './string/title.ts'
 export * from './string/trim.ts'
 
 export * from './typed/assert.ts'
+export * from './typed/getErrorMessage.ts'
 export * from './typed/isArray.ts'
 export * from './typed/isAsyncIterable.ts'
 export * from './typed/isBigInt.ts'

--- a/src/typed/getErrorMessage.ts
+++ b/src/typed/getErrorMessage.ts
@@ -1,0 +1,23 @@
+/**
+ * Gets a readable message from an unknown error value.
+ *
+ * Empty error messages and unsupported values return `"Unknown error."`.
+ *
+ * @see https://radashi.js.org/reference/typed/getErrorMessage
+ * @example
+ * ```ts
+ * getErrorMessage(new Error('Request failed')) // => 'Request failed'
+ * getErrorMessage('Request failed') // => 'Request failed'
+ * getErrorMessage(null) // => 'Unknown error.'
+ * ```
+ * @version 12.8.0
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return typeof error === 'string' && error.length > 0
+    ? error
+    : 'Unknown error.'
+}

--- a/tests/typed/getErrorMessage.test.ts
+++ b/tests/typed/getErrorMessage.test.ts
@@ -1,0 +1,37 @@
+import * as _ from 'radashi'
+
+describe('getErrorMessage', () => {
+  test('returns the message from an Error', () => {
+    const result = _.getErrorMessage(new Error('Request failed'))
+    expect(result).toBe('Request failed')
+  })
+
+  test('returns the message from an Error subclass', () => {
+    const result = _.getErrorMessage(new TypeError('Invalid value'))
+    expect(result).toBe('Invalid value')
+  })
+
+  test('returns a non-empty string error', () => {
+    const result = _.getErrorMessage('Request failed')
+    expect(result).toBe('Request failed')
+  })
+
+  test('returns a fallback for an Error without a message', () => {
+    const result = _.getErrorMessage(new Error())
+    expect(result).toBe('Unknown error.')
+  })
+
+  test('returns a fallback for an empty string', () => {
+    const result = _.getErrorMessage('')
+    expect(result).toBe('Unknown error.')
+  })
+
+  test('returns a fallback for unsupported values', () => {
+    expect(_.getErrorMessage({ message: 'Request failed' })).toBe(
+      'Unknown error.',
+    )
+    expect(_.getErrorMessage(null)).toBe('Unknown error.')
+    expect(_.getErrorMessage(undefined)).toBe('Unknown error.')
+    expect(_.getErrorMessage(123)).toBe('Unknown error.')
+  })
+})


### PR DESCRIPTION
- `catch` values are `unknown`, so callers need a small helper for deriving a safe message without repeating checks.
- Added `getErrorMessage` for `Error` instances and non-empty string throws.
- Falls back to `"Unknown error."` for empty or unsupported values, with docs and tests.

## Bundle impact

| Status | File | Size [^1337] |
| --- | --- | --- |
| A | `src/typed/getErrorMessage.ts` | 141 |

[^1337]: Function size includes the `import` dependencies of the function.



