### PR TITLE
docs: clarify dash digit boundaries

### DIFF
--- a/docs/string/dash.mdx
+++ b/docs/string/dash.mdx
@@ -13,3 +13,12 @@ import * as _ from 'radashi'
 
 _.dash('green fish blue fish') // => green-fish-blue-fish
 ```
+
+`dash` splits on common word separators and camel case boundaries, but it does
+not split adjacent letters and numbers.
+
+```ts twoslash
+import * as _ from 'radashi'
+// ---cut-before---
+_.dash('helloWorld12Bye') // => hello-world12-bye
+```

--- a/tests/string/dash.test.ts
+++ b/tests/string/dash.test.ts
@@ -17,6 +17,10 @@ describe('dash', () => {
     const result = _.dash('helloWorld')
     expect(result).toBe('hello-world')
   })
+  test('does not split letters and numbers', () => {
+    const result = _.dash('helloWorld12Bye')
+    expect(result).toBe('hello-world12-bye')
+  })
   test('must handle strings that are dash', () => {
     const result = _.dash('hello-world')
     expect(result).toBe('hello-world')


### PR DESCRIPTION
## Summary
- Document that `dash` does not split adjacent letters and numbers
- Add a regression test for the current `dash` behavior

## Test
- `CI=true pnpm test-single dash`