### PR TITLE
fix(replaceOrAppend): treat only null/undefined as a missing new item

### DIFF
--- a/src/array/replaceOrAppend.ts
+++ b/src/array/replaceOrAppend.ts
@@ -19,10 +19,10 @@ export function replaceOrAppend<T>(
   newItem: T,
   match: (a: T, idx: number) => boolean,
 ): T[] {
-  if (!array && !newItem) {
+  if (!array && newItem == null) {
     return []
   }
-  if (!newItem) {
+  if (newItem == null) {
     return [...array]
   }
   if (!array) {

--- a/tests/array/replaceOrAppend.test.ts
+++ b/tests/array/replaceOrAppend.test.ts
@@ -44,4 +44,11 @@ describe('replaceOrAppend', () => {
     const result = _.replaceOrAppend(letters, 'XX', x => x === 'x')
     expect(result).toEqual(lettersXX)
   })
+  test('replaces a falsy new item instead of treating it as missing', () => {
+    expect(_.replaceOrAppend([1, 2, 3], 0, n => n === 2)).toEqual([1, 0, 3])
+    expect(_.replaceOrAppend([true], false, x => x === true)).toEqual([false])
+  })
+  test('appends a falsy new item when nothing matches', () => {
+    expect(_.replaceOrAppend([1, 2, 3], 0, n => n > 100)).toEqual([1, 2, 3, 0])
+  })
 })


### PR DESCRIPTION
## Summary

`replaceOrAppend` uses a truthiness check to decide whether a new item was passed:

```ts
if (!array && !newItem) return []
if (!newItem) return [...array]
```

Because `!newItem` is true for any falsy value, a falsy `newItem` such as `0`, `''`, `false`, or `NaN` is treated as "no item" and silently dropped instead of being replaced or appended:

```ts
replaceOrAppend([1, 2, 3], 0, n => n === 2)      // got [1, 2, 3], expected [1, 0, 3]
replaceOrAppend([1, 2, 3], 0, n => n > 100)      // got [1, 2, 3], expected [1, 2, 3, 0]
replaceOrAppend([true], false, x => x === true)  // got [true],    expected [false]
```

The sibling `replace` already handles this correctly because it checks `newItem === undefined`, and `toggle` checks `item === undefined`, so both treat falsy values as valid items. `replaceOrAppend` is the only one of the three that uses a truthiness check.

The fix narrows the guard to `newItem == null`. This still covers `null` and `undefined` (the existing "missing item" tests pass `null`, so that behavior is preserved) while no longer swallowing falsy values. `== null` is the same null/undefined idiom already used elsewhere in the codebase, for example in `select`, `clamp`, and `concat`.

## Related issue, if any:

None.

## For any code change,

- [ ] Related documentation has been updated, if needed
- [x] Related tests have been added or updated, if needed
- [ ] Related benchmarks have been added or updated, if needed
- [ ] Release notes in next-minor.md or next-major.md have been added, if needed

## Does this PR introduce a breaking change?

No


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/array/counting.ts` | 110 | -23 (-17%) |
| M | `src/array/diff.ts` | 209 | -4 (-2%) |
| M | `src/array/replaceOrAppend.ts` | 203 | +10 (+5%) |
| M | `src/string/snake.ts` | 441 | -1 (+0%) |

[^1337]: Function size includes the `import` dependencies of the function.



