### PR TITLE
fix(snake): split every letter-number boundary, not just the first

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -20,6 +20,9 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Create base branch reference
+        run: |
+          git branch ${{ github.base_ref }} HEAD
       - name: Install pnpm
         uses: pnpm/action-setup@v4
       - name: Install Node.js

--- a/src/string/snake.ts
+++ b/src/string/snake.ts
@@ -34,5 +34,5 @@ export function snake(
   })
   return options?.splitOnNumber === false
     ? result
-    : result.replace(/([A-Za-z]{1}[0-9]{1})/, val => `${val[0]!}_${val[1]!}`)
+    : result.replace(/([A-Za-z]{1}[0-9]{1})/g, val => `${val[0]!}_${val[1]!}`)
 }

--- a/tests/string/snake.test.ts
+++ b/tests/string/snake.test.ts
@@ -17,6 +17,10 @@ describe('snake', () => {
     const result = _.snake('hello-world12_19-bye')
     expect(result).toBe('hello_world_12_19_bye')
   })
+  test('splits every letter-number boundary, not just the first', () => {
+    const result = _.snake('a1 b2 c3')
+    expect(result).toBe('a_1_b_2_c_3')
+  })
   test('does not split numbers when flag is set to false', () => {
     const result = _.snake('hello-world12_19-bye', {
       splitOnNumber: false,


### PR DESCRIPTION
## Summary
- `snake` only inserted a separator at the **first** letter-to-number transition because the number-splitting regex lacked the global flag. Inputs with several such boundaries (e.g. `"a1 b2 c3"`) left later numbers unsplit. Add the `g` flag so all boundaries are separated, matching the documented behavior. The `splitOnNumber: false` opt-out is unaffected.
- CI: create a local branch reference after checkout so the benchmark comparison (`git show <branch>:path`) can resolve the branch name under a detached HEAD (otherwise it fails with `fatal: invalid object name`).

## Test plan
`tests/string/snake.test.ts` covers multi-boundary inputs.


## Bundle impact

| Status | File | Size [^1337] | Difference |
| --- | --- | --- | --- |
| M | `src/string/snake.ts` | 442 | +1 (+0%) |

[^1337]: Function size includes the `import` dependencies of the function.



